### PR TITLE
Add verification configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Revised the code base
 - Setting a custom Dafny installation now disables automatic updates
 - Now showing the Dafny installation progress in the terminal
+- Added option to set a time limit for the automatic verification
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Setting a custom Dafny installation now disables automatic updates
 - Now showing the Dafny installation progress in the terminal
 - Added option to set a time limit for the automatic verification
+- Added option to set the number of virtual cores to use for automatic verification
 
 ## 1.8.0
 

--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
           ],
           "description": "When to apply the automatic verification (requires restart)"
         },
+        "dafny.verificationTimeLimit": {
+          "type": "number",
+          "default": "0",
+          "description": "Maximum number of time in seconds to verify a document, 0=infinite (requires restart)"
+        },
         "dafny.languageServerLaunchArgs": {
           "type": "array",
           "default": [],

--- a/package.json
+++ b/package.json
@@ -130,6 +130,11 @@
           "default": "0",
           "description": "Maximum number of time in seconds to verify a document, 0=infinite (requires restart)"
         },
+        "dafny.verificationVirtualCores": {
+          "type": "number",
+          "default": "0",
+          "description": "Maximum number of virtual cores that may be used for verification, 0=auto (requires restart)"
+        },
         "dafny.languageServerLaunchArgs": {
           "type": "array",
           "default": [],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export namespace ConfigurationConstants {
     export const RuntimePath = 'languageServerRuntimePath';
     export const LaunchArgs = 'languageServerLaunchArgs';
     export const AutomaticVerification = 'automaticVerification';
+    export const VerificationTimeLimit = 'verificationTimeLimit';
   }
 
   export namespace Compiler {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export namespace ConfigurationConstants {
     export const LaunchArgs = 'languageServerLaunchArgs';
     export const AutomaticVerification = 'automaticVerification';
     export const VerificationTimeLimit = 'verificationTimeLimit';
+    export const VerificationVirtualCores = 'verificationVirtualCores';
   }
 
   export namespace Compiler {

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -13,11 +13,19 @@ const LanguageServerName = 'Dafny Language Server';
 
 function getLanguageServerLaunchArgs(): string[] {
   const launchArgs = Configuration.get<string[]>(ConfigurationConstants.LanguageServer.LaunchArgs);
-  return [ getVerificationArgument(), ...launchArgs ];
+  return [
+    getVerificationArgument(),
+    getVerifierTimeLimitArgument(),
+    ...launchArgs
+  ];
 }
 
 function getVerificationArgument(): string {
   return `--documents:verify=${Configuration.get<string>(ConfigurationConstants.LanguageServer.AutomaticVerification)}`;
+}
+
+function getVerifierTimeLimitArgument(): string {
+  return `--verifier:timelimit=${Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationTimeLimit)}`;
 }
 
 export class DafnyLanguageClient extends LanguageClient {

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -16,6 +16,7 @@ function getLanguageServerLaunchArgs(): string[] {
   return [
     getVerificationArgument(),
     getVerifierTimeLimitArgument(),
+    getVerifierVirtualCoresArgument(),
     ...launchArgs
   ];
 }
@@ -26,6 +27,10 @@ function getVerificationArgument(): string {
 
 function getVerifierTimeLimitArgument(): string {
   return `--verifier:timelimit=${Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationTimeLimit)}`;
+}
+
+function getVerifierVirtualCoresArgument(): string {
+  return `--verifier:vcscores=${Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationVirtualCores)}`;
 }
 
 export class DafnyLanguageClient extends LanguageClient {


### PR DESCRIPTION
This PR adds VSCode option entries for the following two new language server settings:

- Verification time limit
- Number of virtual cores used by the verification