### PR TITLE
fix: Syntax highlighting for comments in parameters

### DIFF
--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -248,6 +248,18 @@
 					<key>include</key>
 					<string>#generics</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments-inline</string>
+				</dict>
+				<!--dict> Turn on if we want to support nested method calls
+					<key>include</key>
+					<string>$self</string>
+				</dict-->
 			</array>
 		</dict>
 		<key>generics</key>


### PR DESCRIPTION
This PR adds syntax highlighting for comments in parameters and thus solves issues #59  and #62 which are the same.
I also added a comment in case we want to also enable keywords and other expressions.