### PR TITLE
fix: Improve typings to better reflect the target environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -221,9 +221,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.0.tgz",
-			"integrity": "sha512-6N8Sa5AaENRtJnpKXZgvc119PKxT1Lk9VPy4kfT8JF23tIe1qDfaGkBR2DRKJFIA7NptMz+fps//C6aLi1Uoug=="
+			"version": "12.12.70",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.70.tgz",
+			"integrity": "sha512-i5y7HTbvhonZQE+GnUM2rz1Bi8QkzxdQmEv1LKOv4nWyaQk/gdeiTApuQR3PDJHX7WomAbpx2wlWSEpxXGZ/UQ=="
 		},
 		"@types/promise.any": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
   "devDependencies": {
     "@types/glob": "^7.1.4",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^12.12.0",
+    "@types/node": "^12.12.70",
     "@types/promise.any": "^2.0.0",
     "@types/vscode": "^1.52.0",
     "@types/which": "^2.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2021",
+    "target": "es2019",
     "lib": [
-      "ES2021"
+      "es2019"
     ],
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
This PR is a follow-up for issue #80 and PR #81. It updates the `@types/node` package to  `v12.12.70` and downgrades the target library to `ES2019`. With this change, `any` is disclosed as an unknown member of `Promise`.