### PR TITLE
fix: Fix string highlighting for method arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.0.2
+
+- Improved syntax highlighting of strings
+
 ## 2.0.1
 
 - Fixed VSCode compatibility (Promise.any is not a function error)

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -296,6 +296,10 @@
 					<key>include</key>
 					<string>$self</string>
 				</dict-->
+				<dict>
+					<key>include</key>
+					<string>#strings</string>
+				</dict>
 			</array>
 		</dict>
 		<key>generics</key>

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -175,7 +175,7 @@
 					<key>begin</key>
 					<string>"</string>
 					<key>end</key>
-					<string>"</string>
+					<string>("|\n)</string>
 					<key>name</key>
 					<string>string.dafny</string>
 					<key>patterns</key>


### PR DESCRIPTION
Resolves #85 
![image](https://user-images.githubusercontent.com/18049310/142374197-696efb59-16f3-4233-92bc-4986989469db.png)

Furthermore, it mitigates the risk of breaking the syntax highlighting of the whole file if there's anything parsed wrong by terminating strings at the end of the line.