### PR TITLE
Misleading message for compilation fixed

### DIFF
--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -2,7 +2,7 @@ export namespace Messages {
   export namespace CompilationStatus {
     export const ParsingFailed = '$(thumbsdown) Parsing Failed';
     export const ResolutionFailed = '$(thumbsdown) Resolution Failed';
-    export const CompilationSucceeded = 'Resolution succeeded. Awaiting verification...';
+    export const CompilationSucceeded = '$(book) Resolved (not verified)';
     export const Verifying = '$(sync~spin) Verifying...';
     export const VerificationSucceeded = '$(thumbsup) Verification Succeeded';
     export const VerificationFailed = '$(thumbsdown) Verification Failed';

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -2,7 +2,7 @@ export namespace Messages {
   export namespace CompilationStatus {
     export const ParsingFailed = '$(thumbsdown) Parsing Failed';
     export const ResolutionFailed = '$(thumbsdown) Resolution Failed';
-    export const CompilationSucceeded = '$(thumbsup) Compilation Succeeded';
+    export const CompilationSucceeded = 'Resolution succeeded. Awaiting verification...';
     export const Verifying = '$(sync~spin) Verifying...';
     export const VerificationSucceeded = '$(thumbsup) Verification Succeeded';
     export const VerificationFailed = '$(thumbsdown) Verification Failed';


### PR DESCRIPTION
A regular Dafny user pointed out that the compilation message is misleading for several reasons.

Current message:

    '$(thumbsup) Compilation succeeded';

Suggested message:

    'Resolution succeeded. Awaiting verification...';

Here is why:

- "Compilation" is normally the step that happens after verification. Hence, the current messages would indicate that Dafny files were translated before verification even started, which is not the case. Hence, I use the wording "Resolution" which is consistent with the other message `$(thumbsdown) Resolution Failed';`
- I removed $(thumbsup). Until recently, thumbs up was used only when verification succeeded, which makes sense given its "all right" meaning. Providing an intermediate thumbs up at resolution time feels totally unnecessary and even misleading to someone who might think for a second that verification succeeded. We could have an intermediate icon instead, but we should not assign the same icon to two different steps of the process.