### PR TITLE
Enable extension logging for debugging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -120,6 +120,14 @@
     "@typescript-eslint/padding-line-between-statements": "warn",
     "@typescript-eslint/require-array-sort-compare": "warn",
     "@typescript-eslint/ban-types": "warn",
-    "@typescript-eslint/array-type": "warn"
+    "@typescript-eslint/array-type": "warn",
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "selector": "typeParameter",
+        "format": [ "PascalCase" ],
+        "prefix": [ "T" ]
+      }
+    ]
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ class ExtensionRuntime {
 
   private async initializeClient(): Promise<void> {
     this.statusOutput.appendLine(`starting Dafny from ${getLanguageServerRuntimePath(this.context)}`);
-    this.client = await DafnyLanguageClient.create(this.context);
+    this.client = await DafnyLanguageClient.create(this.context, this.statusOutput);
     this.client.start();
     await this.client.onReady();
     this.languageServerVersion = await this.getLanguageServerVersionAfterStartup();

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -105,7 +105,7 @@ export class DafnyLanguageClient extends LanguageClient {
     });
   }
 
-  private sendLoggedRequest<Param, TResult>(route: string, param: Param): Promise<TResult>  {
+  private sendLoggedRequest<TParam, TResult>(route: string, param: TParam): Promise<TResult>  {
     this.statusOutput.appendLine(`Sent ${JSON.stringify(param)} to ${route}`);
     return this.sendRequest<TResult>(route, param);
   }

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -41,17 +41,17 @@ function getMarkGhostStatementsArgument(): string {
 }
 
 export class DafnyLanguageClient extends LanguageClient {
-  private statusOutput: OutputChannel;
+  private readOnly statusOutput: OutputChannel;
 
   // eslint-disable-next-line max-params
   private constructor(
-      id: string,
-      name: string,
-      serverOptions: ServerOptions,
-      clientOptions: LanguageClientOptions,
-      outputChannel: OutputChannel,
-      forceDebug?: boolean
-    ) {
+    id: string,
+    name: string,
+    serverOptions: ServerOptions,
+    clientOptions: LanguageClientOptions,
+    outputChannel: OutputChannel,
+    forceDebug?: boolean
+  ) {
     super(id, name, serverOptions, clientOptions, forceDebug);
     this.statusOutput = outputChannel;
   }
@@ -105,7 +105,7 @@ export class DafnyLanguageClient extends LanguageClient {
     });
   }
 
-  private sendLoggedRequest<TParams, TResult>(route: string, param: TParams): Promise<TResult>  {
+  private sendLoggedRequest<TParams, TResult>(route: string, param: TParams): Promise<TResult> {
     this.statusOutput.appendLine(`Sent ${JSON.stringify(param)} to ${route}`);
     return this.sendRequest<TResult>(route, param);
   }

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -44,15 +44,22 @@ export class DafnyLanguageClient extends LanguageClient {
   private statusOutput: OutputChannel;
 
   // eslint-disable-next-line max-params
-  private constructor(id: string, name: string, serverOptions: ServerOptions,
-      clientOptions: LanguageClientOptions, outputChannel: OutputChannel, forceDebug?: boolean) {
+  private constructor(
+      id: string,
+      name: string,
+      serverOptions: ServerOptions,
+      clientOptions: LanguageClientOptions,
+      outputChannel: OutputChannel,
+      forceDebug?: boolean
+    ) {
     super(id, name, serverOptions, clientOptions, forceDebug);
     this.statusOutput = outputChannel;
   }
 
   public getCounterExamples(param: ICounterExampleParams): Promise<ICounterExampleItem[]> {
     return this.sendLoggedRequest<ICounterExampleParams, ICounterExampleItem[]>(
-      'dafny/counterExample', param);
+      'dafny/counterExample', param
+    );
   }
 
   public static async create(context: ExtensionContext, outputChannel: OutputChannel): Promise<DafnyLanguageClient> {
@@ -90,15 +97,16 @@ export class DafnyLanguageClient extends LanguageClient {
     return this.onLoggedNotification('dafny/verification/completed', callback);
   }
 
-  public onLoggedNotification<Params, Return>(route: string, callback: (params: Params) => Return): Disposable {
-    return this.onNotification(route, (params: Params) => {
-      this.statusOutput.appendLine('Received ' + route);
+  private onLoggedNotification<TParams, TResult>(route: string, callback: (params: TParams) => TResult): Disposable {
+    return this.onNotification(route, (params: TParams) => {
+      this.statusOutput.appendLine(`Received ${route}`);
       this.statusOutput.appendLine(JSON.stringify(params));
       return callback(params);
     });
   }
 
-  public sendLoggedRequest<Param, Return>(route: string, param: Param): Promise<Return>  {
-    return this.sendRequest<Return>(route, param);
+  private sendLoggedRequest<Param, TResult>(route: string, param: Param): Promise<TResult>  {
+    this.statusOutput.appendLine(`Sent ${JSON.stringify(param)} to ${route}`);
+    return this.sendRequest<TResult>(route, param);
   }
 }

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -105,7 +105,7 @@ export class DafnyLanguageClient extends LanguageClient {
     });
   }
 
-  private sendLoggedRequest<TParam, TResult>(route: string, param: TParam): Promise<TResult>  {
+  private sendLoggedRequest<TParams, TResult>(route: string, param: TParams): Promise<TResult>  {
     this.statusOutput.appendLine(`Sent ${JSON.stringify(param)} to ${route}`);
     return this.sendRequest<TResult>(route, param);
   }


### PR DESCRIPTION
It would be helpful for advanced users to understand what happened to the language server before it crashed, because sometimes it becomes unresponsive.
This PR adds the status information to the currently unused statusOutput console of the extension 

To view it, next to the "Problems" tab, click the "Output" tab, and then select in the dropdown to the right "Dafny VSCode"

Before:

```
starting Dafny from <...out\resources\dafny\DafnyLanguageServer.dll>
Dafny is ready
```

After:

```
starting Dafny from <...out\resources\dafny\DafnyLanguageServer.dll>
Received dafnyLanguageServerVersionReceived
"3.3.0.31104"
Dafny is ready
Received dafny/compilation/status
{"uri":"file:///...","version":1,"status":"CompilationSucceeded"}
Received dafny/compilation/status
{"uri":"file:///...","version":1,"status":"VerificationStarted"}
Received dafny/compilation/status
{"uri":"file:///...","version":1,"status":"VerificationSucceeded"}
Received dafny/compilation/status
{"uri":"file:///...","version":2,"status":"CompilationSucceeded"}
Received dafny/compilation/status
{"uri":"file:///...","version":2,"status":"VerificationStarted"}
Received dafny/compilation/status
{"uri":"file:///...","version":2,"status":"VerificationFailed"}
```