### PR TITLE
feat(config): Allow users to turn on caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,21 @@
           "default": "0",
           "description": "Maximum number of virtual cores that may be used for verification, 0=auto (requires restart)"
         },
+        "dafny.verificationCachingPolicy": {
+          "type": "string",
+          "enum": [
+            "No caching",
+            "Basic caching",
+            "Advanced caching"
+          ],
+          "enumDescriptions": [
+            "Reverifies the whole file after each change",
+            "Keeps a per-procedure cache of verification results",
+            "Keeps a per-assertion cache of verification results"
+          ],
+          "default": "No caching",
+          "description": "EXPERIMENTAL: How Dafny reuses previous verification results as a source file is being edited (requires restart)."
+        },
         "dafny.markGhostStatements": {
           "type": "boolean",
           "default": "true",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export namespace ConfigurationConstants {
     export const AutomaticVerification = 'automaticVerification';
     export const VerificationTimeLimit = 'verificationTimeLimit';
     export const VerificationVirtualCores = 'verificationVirtualCores';
+    export const VerificationCachingPolicy = 'verificationCachingPolicy';
     export const MarkGhostStatements = 'markGhostStatements';
   }
 

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -18,6 +18,7 @@ function getLanguageServerLaunchArgs(): string[] {
   return [
     getVerificationArgument(),
     getVerifierTimeLimitArgument(),
+    getVerifierCachingPolicy(),
     getVerifierVirtualCoresArgument(),
     getMarkGhostStatementsArgument(),
     ...launchArgs
@@ -30,6 +31,16 @@ function getVerificationArgument(): string {
 
 function getVerifierTimeLimitArgument(): string {
   return `--verifier:timelimit=${Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationTimeLimit)}`;
+}
+
+function getVerifierCachingPolicy(): string {
+  const setting = Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationCachingPolicy);
+  const verifySnapshots = {
+    'No caching': 0,
+    'Basic caching': 1,
+    'Advanced caching': 3
+  }[setting] ?? 0;
+  return `--verifier:verifySnapshots=${verifySnapshots}`;
 }
 
 function getVerifierVirtualCoresArgument(): string {


### PR DESCRIPTION
This is the companion PR of https://github.com/dafny-lang/dafny/pull/1654 ; it's intended to let users experiment with caching in VSCode (caching is on by default in Emacs)