### PR TITLE
checkDotnetInstallation: do not error out with ASP.NET Core Runtime 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can find [examples below](#examples).
 
 ## Requirements
 
-The plugin requires at least .NET Core 5.0 (the ASP.NET Core 5.0 runtime to be more specific) to run the _Dafny Language Server_. Please download a distribution from [Microsoft](https://dotnet.microsoft.com/download).
+The plugin requires at least .NET Core 5.0 (the ASP.NET Core 5.0 or 6.0 runtimes to be more specific) to run the _Dafny Language Server_. Please download a distribution from [Microsoft](https://dotnet.microsoft.com/download).
 When you first open a _Dafny_ file, the extension will prompt you to install .NET Core manually. The language server gets installed automatically.
 
 ## Extension Settings

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,7 +37,7 @@ export namespace ConfigurationConstants {
 
 export namespace DotnetConstants {
   export const ExecutableName = 'dotnet';
-  export const SupportedRuntimesPattern = /Microsoft\.AspNetCore\.App\s*5\.0/i;
+  export const SupportedRuntimesPattern = /Microsoft\.AspNetCore\.App\s*[56]\.0/i;
 }
 
 export namespace LanguageServerConstants {

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -22,9 +22,9 @@ export namespace Messages {
   }
 
   export namespace Dotnet {
-    export const NoCompatibleInstallation = 'There is no compatible dotnet runtime installed. Dafny requires the ASP.NET Core Runtime 5.0.';
+    export const NoCompatibleInstallation = 'There is no compatible dotnet runtime installed. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
     export const ChangeConfiguration = 'Change dafny.dotnetExecutablePath';
     export const VisitDownload = 'Get dotnet';
-    export const DownloadUri = 'https://dotnet.microsoft.com/download/dotnet/5.0';
+    export const DownloadUri = 'https://dotnet.microsoft.com/download/dotnet/6.0';
   }
 }


### PR DESCRIPTION
As discussed in #110, the check that the installed dotnet is precisely version 5.0 might be overly specific.  (In particular, the exact requirement for version 5.0 means no M1 Mac users can use the plugin since only x64 binaries are available for that version of the runtime).

This patch simply relaxes the regex that is matched against the output of `dotnet --list-runtimes` to allow either versions 5.0 or 6.0.

I forked the plugin and wrote this patch for my own personal use; however, I thought perhaps the team would like to consider whether it's worth merging in advance of Dafny 3.4, which @camrein mentioned will be targeting 6.0.  Thanks!