### PR TITLE
Fix empty configuration path that leads to the extension not working

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -15,16 +15,9 @@ import Configuration from '../configuration';
 const ArchiveFileName = 'dafny.zip';
 const mkdirAsync = promisify(fs.mkdir);
 
-// If someone deletes a configured language server runtime or compiler path, there will remain an empty string.
-// Previously, it would have been interpreted wrongly like a "relative path".
-// Now it is interpreted as "switch back to default"
-function ifNullOrEmpty(a: string | null, b: string) {
-  return a === "" || a == null ? b : a;
-}
-
 export function getCompilerRuntimePath(context: ExtensionContext): string {
-  const configuredPath = ifNullOrEmpty(Configuration.get<string | null>(ConfigurationConstants.Compiler.RuntimePath)
-    , LanguageServerConstants.DefaultCompilerPath);
+  const configuredPath = Configuration.get<string | null>(ConfigurationConstants.Compiler.RuntimePath)
+    || LanguageServerConstants.DefaultCompilerPath;
   if(!path.isAbsolute(configuredPath)) {
     return path.join(context.extensionPath, configuredPath);
   }
@@ -32,7 +25,7 @@ export function getCompilerRuntimePath(context: ExtensionContext): string {
 }
 
 export function getLanguageServerRuntimePath(context: ExtensionContext): string {
-  const configuredPath = ifNullOrEmpty(getConfiguredLanguageServerRuntimePath(), LanguageServerConstants.DefaultPath);
+  const configuredPath = getConfiguredLanguageServerRuntimePath() || LanguageServerConstants.DefaultPath;
   if(path.isAbsolute(configuredPath)) {
     return configuredPath;
   }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -16,8 +16,8 @@ const ArchiveFileName = 'dafny.zip';
 const mkdirAsync = promisify(fs.mkdir);
 
 // Equivalent to a || b but without ESLint warnings
-function ifNullOrEmpty(a: string | null, b: string) {
-  return a === null || a === '' ? a : b;
+function ifNullOrEmpty(a: string | null, b: string): string {
+  return a === null || a === '' ? b : a;
 }
 
 export function getCompilerRuntimePath(context: ExtensionContext): string {

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -15,9 +15,14 @@ import Configuration from '../configuration';
 const ArchiveFileName = 'dafny.zip';
 const mkdirAsync = promisify(fs.mkdir);
 
+// Equivalent to a || b but without ESLint warnings
+function ifNullOrEmpty(a: string | null, b: string) {
+  return a ? a : b;
+}
+
 export function getCompilerRuntimePath(context: ExtensionContext): string {
-  const configuredPath = Configuration.get<string | null>(ConfigurationConstants.Compiler.RuntimePath)
-    || LanguageServerConstants.DefaultCompilerPath;
+  const configuredPath = ifNullOrEmpty(Configuration.get<string | null>(ConfigurationConstants.Compiler.RuntimePath)
+    , LanguageServerConstants.DefaultCompilerPath);
   if(!path.isAbsolute(configuredPath)) {
     return path.join(context.extensionPath, configuredPath);
   }
@@ -25,7 +30,7 @@ export function getCompilerRuntimePath(context: ExtensionContext): string {
 }
 
 export function getLanguageServerRuntimePath(context: ExtensionContext): string {
-  const configuredPath = getConfiguredLanguageServerRuntimePath() || LanguageServerConstants.DefaultPath;
+  const configuredPath = ifNullOrEmpty(getConfiguredLanguageServerRuntimePath(), LanguageServerConstants.DefaultPath);
   if(path.isAbsolute(configuredPath)) {
     return configuredPath;
   }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -15,9 +15,16 @@ import Configuration from '../configuration';
 const ArchiveFileName = 'dafny.zip';
 const mkdirAsync = promisify(fs.mkdir);
 
+// If someone deletes a configured language server runtime or compiler path, there will remain an empty string.
+// Previously, it would have been interpreted wrongly like a "relative path".
+// Now it is interpreted as "switch back to default"
+function ifNullOrEmpty(a: string | null, b: string) {
+  return a === "" || a == null ? b : a;
+}
+
 export function getCompilerRuntimePath(context: ExtensionContext): string {
-  const configuredPath = Configuration.get<string | null>(ConfigurationConstants.Compiler.RuntimePath)
-    ?? LanguageServerConstants.DefaultCompilerPath;
+  const configuredPath = ifNullOrEmpty(Configuration.get<string | null>(ConfigurationConstants.Compiler.RuntimePath)
+    , LanguageServerConstants.DefaultCompilerPath);
   if(!path.isAbsolute(configuredPath)) {
     return path.join(context.extensionPath, configuredPath);
   }
@@ -25,7 +32,7 @@ export function getCompilerRuntimePath(context: ExtensionContext): string {
 }
 
 export function getLanguageServerRuntimePath(context: ExtensionContext): string {
-  const configuredPath = getConfiguredLanguageServerRuntimePath() ?? LanguageServerConstants.DefaultPath;
+  const configuredPath = ifNullOrEmpty(getConfiguredLanguageServerRuntimePath(), LanguageServerConstants.DefaultPath);
   if(path.isAbsolute(configuredPath)) {
     return configuredPath;
   }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -17,7 +17,7 @@ const mkdirAsync = promisify(fs.mkdir);
 
 // Equivalent to a || b but without ESLint warnings
 function ifNullOrEmpty(a: string | null, b: string) {
-  return a ? a : b;
+  return a == null || a == "" ? a : b;
 }
 
 export function getCompilerRuntimePath(context: ExtensionContext): string {

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -17,7 +17,7 @@ const mkdirAsync = promisify(fs.mkdir);
 
 // Equivalent to a || b but without ESLint warnings
 function ifNullOrEmpty(a: string | null, b: string) {
-  return a == null || a == "" ? a : b;
+  return a === null || a === '' ? a : b;
 }
 
 export function getCompilerRuntimePath(context: ExtensionContext): string {


### PR DESCRIPTION
If someone deletes a configured language server runtime or compiler path, there will remain an empty string.

Previously, it would have been interpreted wrongly like a "relative path", and users would have needed to click on the gears icon next to the setting, and click "reset", which is unintuitive, since it was empty when they first edited it.

With this commit, it is correctly interpreted as "switch back to default"

This would have saved me the first time, and I just learned it would have saved someone else from spending a few hours of trouble.

Fixes #105 