### PR TITLE
fix: Make selection inside ghost statements visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.0
 
 - Added option to specify the preferred dafny version for automatic installation
+- Fixed the text selection for highlighted ghost statements
 
 ## 2.1.1
 

--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -7,10 +7,10 @@ import { getVsDocumentPath, toVsRange } from '../tools/vscode';
 
 const GhostDecoration: DecorationRenderOptions = {
   dark: {
-    backgroundColor: '#323232'
+    backgroundColor: '#64646480'
   },
   light: {
-    backgroundColor: '#f2f2f2'
+    backgroundColor: '#79797980'
   }
 };
 


### PR DESCRIPTION
This PR partially fixes #126 by making the text selection inside ghost statements visible. This is achieved by setting the opacity (hex alpha channel) to 50% of the decorator's background color.
![image](https://user-images.githubusercontent.com/18049310/153186214-365263b7-819f-4239-9b38-ba13c8e4e636.png)

PS: As I cannot unlink issue #126, please reopen it after merging since there is another part to it.
