### PR TITLE
fix: type ascription should not be applicable to double colon

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,7 @@
+function test() {
+  set x | 0 < x < 10 :: predicate(x)
+}//                     ^^^^^^^^^ should be a function call, not a type
+
 // Issue #121: Generic and Regular should be highlighted
 // with the same color
 predicate Generic<Bar>(foo: Bar){}

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -480,7 +480,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(?<!\{):\s*([\w'?]+\b(?!&lt;))</string>
+					<string>(?<!\{|:):\s*([\w'?]+\b(?!&lt;))</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Note that the second "id" is no longer understood as a type (previously it was matching ": id" as a type ascription), but now it's understood a function correctly.

Before:
![image](https://user-images.githubusercontent.com/3601079/153892612-6377e3d4-7d19-4158-9ca2-4117e7b72480.png)

After:
![image](https://user-images.githubusercontent.com/3601079/153893029-0866fb61-62e7-4b84-9439-37c3e3d324f3.png)
