### PR TITLE
fix: Occasionally missing red squiggles under errors

### DIFF
--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -1,4 +1,4 @@
-import { DecorationOptions, TextEditorDecorationType, window, ExtensionContext, workspace, DecorationRenderOptions, TextEditor } from 'vscode';
+import { DecorationOptions, window, ExtensionContext, workspace, DecorationRenderOptions, TextEditor } from 'vscode';
 import { Diagnostic } from 'vscode-languageclient';
 
 import { IGhostDiagnosticsParams } from '../language/api/ghostDiagnostics';

--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -15,7 +15,7 @@ const GhostDecoration: DecorationRenderOptions = {
 };
 
 export default class GhostDiagnosticsView {
-  private readonly dataByDocument = new Map<string, Diagnostic[]>();
+  private readonly diagnosticsByDocument = new Map<string, Diagnostic[]>();
   private readonly decoration = window.createTextEditorDecorationType(GhostDecoration);
 
   private constructor() {}
@@ -38,7 +38,7 @@ export default class GhostDiagnosticsView {
     if(diagnostics.length === 0) {
       return;
     }
-    this.dataByDocument.set(documentPath, diagnostics);
+    this.diagnosticsByDocument.set(documentPath, diagnostics);
     this.refreshDisplayedGhostDiagnostics(window.activeTextEditor);
   }
 
@@ -47,16 +47,16 @@ export default class GhostDiagnosticsView {
       return;
     }
     const documentPath = editor.document.uri.toString();
-    const data = this.dataByDocument.get(documentPath);
-    if(data == null) {
+    const diagnostics = this.diagnosticsByDocument.get(documentPath);
+    if(diagnostics == null) {
       return;
     }
-    const decorators = data.map(diagnostic => GhostDiagnosticsView.createDecorator(diagnostic));
+    const decorators = diagnostics.map(diagnostic => GhostDiagnosticsView.createDecorator(diagnostic));
     editor.setDecorations(this.decoration, decorators);
   }
 
   private clearGhostDiagnostics(documentPath: string): void {
-    this.dataByDocument.delete(documentPath);
+    this.diagnosticsByDocument.delete(documentPath);
   }
 
   private static createDecorator(diagnostic: Diagnostic): DecorationOptions {

--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -24,7 +24,7 @@ export default class GhostDiagnosticsView {
     const instance = new GhostDiagnosticsView();
     context.subscriptions.push(
       workspace.onDidCloseTextDocument(document => instance.clearGhostDiagnostics(document.uri.toString())),
-      window.onDidChangeActiveTextEditor(editor => instance.handleEditorChange(editor)),
+      window.onDidChangeActiveTextEditor(editor => instance.refreshDisplayedGhostDiagnostics(editor)),
       languageClient.onGhostDiagnostics(params => instance.updateGhostDiagnostics(params)),
       instance
     );
@@ -40,13 +40,6 @@ export default class GhostDiagnosticsView {
     }
     this.dataByDocument.set(documentPath, diagnostics);
     this.refreshDisplayedGhostDiagnostics(window.activeTextEditor);
-  }
-
-  private handleEditorChange(editor?: TextEditor): void {
-    if(editor == null) {
-      return;
-    }
-    this.refreshDisplayedGhostDiagnostics(editor);
   }
 
   private refreshDisplayedGhostDiagnostics(editor?: TextEditor): void {


### PR DESCRIPTION
This PR intends to resolve/mitigate #139. However, I couldn't reproduce the issue myself so I can't confirm the fix myself. Moreover, it may improve the mixed experience reported in #126.
Instead of creating a new decoration object with every request, only a single one is created.