### PR TITLE
Fix: Avoid out-of-order messages

### DIFF
--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -27,10 +27,15 @@ function toStatusMessage(status: CompilationStatus, message?: string | null): st
   }
 }
 
+interface DocumentStatusMessage {
+  status: string;
+  version: number | undefined;
+}
+
 export default class CompilationStatusView {
   // We store the message string for easier backwards compatibility with the
   // legacy status messages.
-  private readonly documentStatusMessages = new Map<string, string>();
+  private readonly documentStatusMessages = new Map<string, DocumentStatusMessage>();
 
   private constructor(private readonly statusBarItem: StatusBarItem) {}
 
@@ -55,18 +60,32 @@ export default class CompilationStatusView {
     this.updateActiveDocumentStatus();
   }
 
+  private areParamsOutdated(params: ICompilationStatusParams): boolean {
+    const previous = this.documentStatusMessages.get(getVsDocumentPath(params));
+    return previous?.version !== undefined && params.version !== undefined
+       && previous.version > params.version;
+  }
+
   private compilationStatusChanged(params: ICompilationStatusParams): void {
+    if(this.areParamsOutdated(params)) {
+      return;
+    }
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
-      toStatusMessage(params.status, params.message)
+      { status: toStatusMessage(params.status, params.message),
+        version: params.version
+      }
     );
     this.updateActiveDocumentStatus();
   }
 
+  // Legacy methods
   private verificationStarted(params: IVerificationStartedParams): void {
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
-      Messages.CompilationStatus.Verifying
+      { status: Messages.CompilationStatus.Verifying,
+        version: undefined
+      }
     );
     this.updateActiveDocumentStatus();
   }
@@ -74,7 +93,9 @@ export default class CompilationStatusView {
   private verificationCompleted(params: IVerificationCompletedParams): void {
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
-      params.verified ? Messages.CompilationStatus.Verified : Messages.CompilationStatus.NotVerified
+      { status: params.verified ? Messages.CompilationStatus.Verified : Messages.CompilationStatus.NotVerified,
+        version: undefined
+      }
     );
     this.updateActiveDocumentStatus();
   }
@@ -84,6 +105,6 @@ export default class CompilationStatusView {
     if(document == null) {
       return;
     }
-    this.statusBarItem.text = this.documentStatusMessages.get(document) ?? '';
+    this.statusBarItem.text = this.documentStatusMessages.get(document)?.status ?? '';
   }
 }

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -29,7 +29,7 @@ function toStatusMessage(status: CompilationStatus, message?: string | null): st
 
 interface DocumentStatusMessage {
   status: string;
-  version: number | undefined;
+  version?: number;
 }
 
 export default class CompilationStatusView {
@@ -73,8 +73,7 @@ export default class CompilationStatusView {
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
       { status: toStatusMessage(params.status, params.message),
-        version: params.version
-      }
+        version: params.version }
     );
     this.updateActiveDocumentStatus();
   }
@@ -83,9 +82,7 @@ export default class CompilationStatusView {
   private verificationStarted(params: IVerificationStartedParams): void {
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
-      { status: Messages.CompilationStatus.Verifying,
-        version: undefined
-      }
+      { status: Messages.CompilationStatus.Verifying }
     );
     this.updateActiveDocumentStatus();
   }
@@ -93,9 +90,7 @@ export default class CompilationStatusView {
   private verificationCompleted(params: IVerificationCompletedParams): void {
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
-      { status: params.verified ? Messages.CompilationStatus.Verified : Messages.CompilationStatus.NotVerified,
-        version: undefined
-      }
+      { status: params.verified ? Messages.CompilationStatus.Verified : Messages.CompilationStatus.NotVerified }
     );
     this.updateActiveDocumentStatus();
   }

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -72,7 +72,8 @@ export default class CompilationStatusView {
     }
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
-      { status: toStatusMessage(params.status, params.message),
+      {
+        status: toStatusMessage(params.status, params.message),
         version: params.version
       }
     );

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -27,7 +27,7 @@ function toStatusMessage(status: CompilationStatus, message?: string | null): st
   }
 }
 
-interface DocumentStatusMessage {
+interface IDocumentStatusMessage {
   status: string;
   version?: number;
 }
@@ -35,7 +35,7 @@ interface DocumentStatusMessage {
 export default class CompilationStatusView {
   // We store the message string for easier backwards compatibility with the
   // legacy status messages.
-  private readonly documentStatusMessages = new Map<string, DocumentStatusMessage>();
+  private readonly documentStatusMessages = new Map<string, IDocumentStatusMessage>();
 
   private constructor(private readonly statusBarItem: StatusBarItem) {}
 
@@ -62,7 +62,7 @@ export default class CompilationStatusView {
 
   private areParamsOutdated(params: ICompilationStatusParams): boolean {
     const previous = this.documentStatusMessages.get(getVsDocumentPath(params));
-    return previous?.version !== undefined && params.version !== undefined
+    return previous?.version != null && params.version != null
        && previous.version > params.version;
   }
 
@@ -73,7 +73,8 @@ export default class CompilationStatusView {
     this.documentStatusMessages.set(
       getVsDocumentPath(params),
       { status: toStatusMessage(params.status, params.message),
-        version: params.version }
+        version: params.version
+      }
     );
     this.updateActiveDocumentStatus();
   }


### PR DESCRIPTION
I witnessed that sometimes verification is not canceled in a timely manner, leading to obsolete notifications to be received by the client. This PR ensures that obsolete notifications are not sent if notifications for a newer document is available.