### PR TITLE
Better error if dotnet is not installed or not configured properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
         },
         "dafny.dotnetExecutablePath": {
           "type": "string",
-          "description": "The absolute path of dotnet. Only necessary if dotnet is not in system PATH (you'll get an error if that's the case)."
+          "description": "The absolute path of the dotnet binary. Only necessary if dotnet is not in system PATH (you'll get an error if that's the case)."
         },
         "dafny.colorCounterExamples": {
           "type": "object",

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -16,7 +16,7 @@ const lstatAsync = promisify(fs.lstat);
 export async function checkSupportedDotnetVersion(): Promise<string | undefined> {
   const { path: dotnetExecutable, manual } = await getDotnetExecutablePath();
   try {
-    const stats = await lstatAsync(dotnetExecutable) as fs.Stats;
+    const stats = await lstatAsync(dotnetExecutable);
     if(!stats.isFile()) {
       return dotnetExecutable + Messages.Dotnet.IsNotAnExecutableFile;
     }

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -1,34 +1,42 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import * as fs from 'fs';
 
 import * as which from 'which';
 
 import { ConfigurationConstants, DotnetConstants } from './constants';
 import Configuration from './configuration';
+import { Messages } from './ui/messages';
 
 const ListRuntimesArg = '--list-runtimes';
 const execFileAsync = promisify(execFile);
 
-export async function hasSupportedDotnetVersion(): Promise<boolean> {
-  const dotnetExecutable = await getDotnetExecutablePath();
+// Returns an error message
+export async function hasSupportedDotnetVersion(): Promise<string> {
+  const { path: dotnetExecutable, manual } = await getDotnetExecutablePath();
   try {
+    if(!fs.lstatSync(dotnetExecutable).isFile()) {
+      return dotnetExecutable + Messages.Dotnet.IsNotAnExecutableFile;
+    }
     const { stdout } = await execFileAsync(dotnetExecutable, [ ListRuntimesArg ]);
-    return DotnetConstants.SupportedRuntimesPattern.test(stdout);
+    return DotnetConstants.SupportedRuntimesPattern.test(stdout) ? ''
+      : dotnetExecutable + Messages.Dotnet.NotASupportedDotnetInstallation + stdout;
   } catch(error: unknown) {
-    console.error(`error invoking ${DotnetConstants.ExecutableName} ${ListRuntimesArg}: ${error}`);
+    const errorMsg = `Error invoking ${dotnetExecutable} ${ListRuntimesArg}: ${error}`;
+    console.error(errorMsg);
+    return manual ? errorMsg : Messages.Dotnet.NoCompatibleInstallation;
   }
-  return false;
 }
 
-export async function getDotnetExecutablePath(): Promise<string> {
+export async function getDotnetExecutablePath(): Promise<{ path: string, manual: boolean }> {
   const configuredPath = Configuration.get<string>(ConfigurationConstants.Dotnet.ExecutablePath).trim();
   if(configuredPath.length > 0) {
-    return configuredPath;
+    return { path: configuredPath, manual: true };
   }
   try {
     const resolvedPath = await which(DotnetConstants.ExecutableName);
-    return resolvedPath;
+    return { path: resolvedPath, manual: false };
   } catch(error: unknown) {
-    return DotnetConstants.ExecutableName;
+    return { path: DotnetConstants.ExecutableName, manual: false };
   }
 }

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -83,7 +83,7 @@ export class DafnyLanguageClient extends LanguageClient {
   }
 
   public static async create(context: ExtensionContext, statusOutput: OutputChannel): Promise<DafnyLanguageClient> {
-    const dotnetExecutable = await getDotnetExecutablePath();
+    const { path: dotnetExecutable } = await getDotnetExecutablePath();
     const launchArguments = [ getLanguageServerRuntimePath(context), ...getLanguageServerLaunchArgs() ];
     statusOutput.appendLine(`Language server arguments: ${DafnyLanguageClient.argumentsToCommandLine(launchArguments)}`);
     const serverOptions: ServerOptions = {

--- a/src/startupCheck.ts
+++ b/src/startupCheck.ts
@@ -1,7 +1,7 @@
 import { window, commands, Uri } from 'vscode';
 
 import { VSCodeCommands } from './commands';
-import { hasSupportedDotnetVersion } from './dotnet';
+import { checkSupportedDotnetVersion } from './dotnet';
 import { Messages } from './ui/messages';
 
 export default async function checkAndInformAboutInstallation(): Promise<boolean> {
@@ -9,8 +9,8 @@ export default async function checkAndInformAboutInstallation(): Promise<boolean
 }
 
 async function checkDotnetInstallation(): Promise<boolean> {
-  const answer = await hasSupportedDotnetVersion();
-  if(answer !== '') {
+  const answer = await checkSupportedDotnetVersion();
+  if(answer !== undefined) {
     const selection = await window.showErrorMessage(
       answer,
       Messages.Dotnet.ChangeConfiguration,

--- a/src/startupCheck.ts
+++ b/src/startupCheck.ts
@@ -9,9 +9,10 @@ export default async function checkAndInformAboutInstallation(): Promise<boolean
 }
 
 async function checkDotnetInstallation(): Promise<boolean> {
-  if(!await hasSupportedDotnetVersion()) {
+  const answer = await hasSupportedDotnetVersion();
+  if(answer !== '') {
     const selection = await window.showErrorMessage(
-      Messages.Dotnet.NoCompatibleInstallation,
+      answer,
       Messages.Dotnet.ChangeConfiguration,
       Messages.Dotnet.VisitDownload
     );

--- a/src/ui/compileCommands.ts
+++ b/src/ui/compileCommands.ts
@@ -61,7 +61,7 @@ class CommandFactory {
 
   public async createCompilerCommand(): Promise<string | undefined> {
     const commandPrefix = this.getCommandPrefix();
-    const dotnetPath = await getDotnetExecutablePath();
+    const { path: dotnetPath } = await getDotnetExecutablePath();
     const compilerPath = getCompilerRuntimePath(this.context);
     const compilerArgs = await this.getCompilerArgs();
     if(compilerArgs == null) {

--- a/src/ui/dafnyVersionView.ts
+++ b/src/ui/dafnyVersionView.ts
@@ -20,7 +20,7 @@ async function getTooltipText(context: ExtensionContext, languageServerVersion: 
 }
 
 async function getCompilerVersion(context: ExtensionContext): Promise<string> {
-  const dotnetPath = await getDotnetExecutablePath();
+  const { path: dotnetPath } = await getDotnetExecutablePath();
   const compilerPath = getCompilerRuntimePath(context);
   try {
     const { stdout } = await execFileAsync(dotnetPath, [ compilerPath, CompilerVersionArg ]);

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -24,6 +24,7 @@ export namespace Messages {
   export namespace Dotnet {
     export const IsNotAnExecutableFile = ' is not an executable dotnet file.';
     export const NotASupportedDotnetInstallation = ' is not a compatible dotnet file. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0, got ';
+    export const FailedDotnetExecution = 'Failed to execute dotnet. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
     export const NoCompatibleInstallation = 'No compatible dotnet runtime found. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
     export const ChangeConfiguration = 'Change dafny.dotnetExecutablePath';
     export const VisitDownload = 'Get dotnet';

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -22,7 +22,9 @@ export namespace Messages {
   }
 
   export namespace Dotnet {
-    export const NoCompatibleInstallation = 'There is no compatible dotnet runtime installed. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
+    export const IsNotAnExecutableFile = ' is not an executable dotnet file.';
+    export const NotASupportedDotnetInstallation = ' is not a compatible dotnet file. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0, got ';
+    export const NoCompatibleInstallation = 'No compatible dotnet runtime found. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
     export const ChangeConfiguration = 'Change dafny.dotnetExecutablePath';
     export const VisitDownload = 'Get dotnet';
     export const DownloadUri = 'https://dotnet.microsoft.com/download/dotnet/6.0';


### PR DESCRIPTION
Fixes #112 

If we specify a directory
![image](https://user-images.githubusercontent.com/3601079/169556358-92e12607-2563-4c71-9e98-5795a1e7918a.png)

If we specify an executable that is not a compatible dotnet file
![image](https://user-images.githubusercontent.com/3601079/169556656-505b4ef6-595e-46ca-9998-7e358c4faba9.png)

If we specify a _file_ that is not executable (sic!), at least we don't get the "no compatible dotnet installed", we get an explicit error about what happened
![image](https://user-images.githubusercontent.com/3601079/169557471-4b523516-00f5-4908-b11f-714f013b01ea.png)

Finally, I changed the default error message from `There is no compatible dotnet runtime installed` to `No compatible dotnet runtime found`, and this message is shown only if the user did not specify an explicit dotnet path.

