### PR TITLE
If language server path "" should be the same as null.

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -174,7 +174,8 @@ export class DafnyInstaller {
   }
 
   public isCustomInstallation(): boolean {
-    return getConfiguredLanguageServerRuntimePath() != null;
+    const configuredLanguageServerRuntimePath = getConfiguredLanguageServerRuntimePath();
+    return configuredLanguageServerRuntimePath != null && configuredLanguageServerRuntimePath !== '';
   }
 
   public async isLanguageServerRuntimeAccessible(): Promise<boolean> {


### PR DESCRIPTION
If the user empties the field "language server path", it should be treated the same as if it was null. It's totally unobvious to have to "reset" this parameter.

Before this PR, a setting like this:
![image](https://user-images.githubusercontent.com/3601079/169921376-0c20102f-5935-4829-b579-881305559450.png)
was setting the language server path to "" and since it was non-null, it would not let the extension download Dafny, for example.