### PR TITLE
Feat: Hint if brew not found.

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -153,7 +153,12 @@ export class DafnyInstaller {
     this.writeStatus(`Installing Dafny from source in ${installationPath.fsPath}.\n`);
     const previousDirectory = processCwd();
     processChdir(installationPath.fsPath);
-    await this.execLog('brew install dotnet-sdk');
+    try {
+      await this.execLog('brew install dotnet-sdk');
+    } catch(error: unknown) {
+      this.writeStatus('If you got `brew: command not found`, but brew is installed on your system, please follow https://apple.stackexchange.com/a/430904 and reinstall Dafny.');
+      return false;
+    }
     await this.execLog(`git clone --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);
     processChdir(Utils.joinPath(installationPath, 'dafny').fsPath);
     await this.execLog('git fetch --all --tags');

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -156,7 +156,7 @@ export class DafnyInstaller {
     try {
       await this.execLog('brew install dotnet-sdk');
     } catch(error: unknown) {
-      this.writeStatus('If you got `brew: command not found`, but brew is installed on your system, please add all brew commends to your ~/.zprofile, e.g. https://apple.stackexchange.com/a/430904 and reinstall Dafny.');
+      this.writeStatus('If you got `brew: command not found`, but brew is installed on your system, please add all brew commands to your ~/.zprofile, e.g. https://apple.stackexchange.com/a/430904 and reinstall Dafny.');
       return false;
     }
     await this.execLog(`git clone --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -156,7 +156,7 @@ export class DafnyInstaller {
     try {
       await this.execLog('brew install dotnet-sdk');
     } catch(error: unknown) {
-      this.writeStatus('If you got `brew: command not found`, but brew is installed on your system, please follow https://apple.stackexchange.com/a/430904 and reinstall Dafny.');
+      this.writeStatus('If you got `brew: command not found`, but brew is installed on your system, please add all brew commends to your ~/.zprofile, e.g. https://apple.stackexchange.com/a/430904 and reinstall Dafny.');
       return false;
     }
     await this.execLog(`git clone --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);


### PR DESCRIPTION
I just solved the case of someone with a Mac M1 architecture, brew installed, but VSCode couldn't run it within the Dafny extension.
After finding the Stackoverflow post that solved the problem, I add a link to it for future users.
