### PR TITLE
Enable configuring a custom language server through an environment variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
-      "name": "Run with custom server",
+      "name": "Run with $DAFNY_LANGUAGE_SERVER",
       "type": "extensionHost",
       "request": "launch",
       "args": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run Extension",
+      "name": "Run with default server",
       "type": "extensionHost",
       "request": "launch",
       "args": [
@@ -15,6 +15,9 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],
+      "env": {
+        "DAFNY_LANGUAGE_SERVER": "",
+      },
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
@@ -24,9 +27,6 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
-      "env": {
-        "DAFNY_LANGUAGE_SERVER": "${env:CUSTOM_DAFNY_SERVER}", 
-      },
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,9 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
+      "env": {
+        "DAFNY_LANGUAGE_SERVER": "${env:CUSTOM_DAFNY_SERVER}", 
+      },
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,18 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "name": "Run with custom server",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
       "env": {
         "DAFNY_LANGUAGE_SERVER": "${env:CUSTOM_DAFNY_SERVER}", 
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "publisher": "dafny-lang",
   "repository": {
     "type": "git",

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -10,13 +10,12 @@ import { Messages } from './ui/messages';
 
 const ListRuntimesArg = '--list-runtimes';
 const execFileAsync = promisify(execFile);
-const lstatAsync = promisify(fs.lstat);
 
 // Returns an error message or undefined.
 export async function checkSupportedDotnetVersion(): Promise<string | undefined> {
   const { path: dotnetExecutable, manual } = await getDotnetExecutablePath();
   try {
-    const stats = await lstatAsync(dotnetExecutable);
+    const stats = await fs.promises.stat(dotnetExecutable);
     if(!stats.isFile()) {
       return dotnetExecutable + Messages.Dotnet.IsNotAnExecutableFile;
     }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -58,7 +58,8 @@ export function getLanguageServerRuntimePath(context: ExtensionContext): string 
 }
 
 function getConfiguredLanguageServerRuntimePath(): string | null {
-  return Configuration.get<string | null>(ConfigurationConstants.LanguageServer.RuntimePath);
+  const languageServerOverride = process.env['DAFNY_LANGUAGE_SERVER'];
+  return languageServerOverride ?? Configuration.get<string | null>(ConfigurationConstants.LanguageServer.RuntimePath);
 }
 
 function getDafnyPlatformSuffix(): string {

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 
-import { workspace, ExtensionContext, Uri, OutputChannel, FileSystemError } from 'vscode';
+import { workspace, ExtensionContext, Uri, OutputChannel, FileSystemError, window } from 'vscode';
 import { Utils } from 'vscode-uri';
 
 import got from 'got';
@@ -59,6 +59,9 @@ export function getLanguageServerRuntimePath(context: ExtensionContext): string 
 
 function getConfiguredLanguageServerRuntimePath(): string {
   const languageServerOverride = process.env['DAFNY_LANGUAGE_SERVER'] ?? '';
+  if(languageServerOverride) {
+    window.showInformationMessage('Using Dafny language server configured in $DAFNY_LANGUAGE_SERVER');
+  }
   const languageServerSetting = Configuration.get<string | null>(ConfigurationConstants.LanguageServer.RuntimePath) ?? '';
   return languageServerOverride || languageServerSetting;
 }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -57,9 +57,10 @@ export function getLanguageServerRuntimePath(context: ExtensionContext): string 
   return path.join(context.extensionPath, configuredPath);
 }
 
-function getConfiguredLanguageServerRuntimePath(): string | null {
-  const languageServerOverride = process.env['DAFNY_LANGUAGE_SERVER'];
-  return languageServerOverride ?? Configuration.get<string | null>(ConfigurationConstants.LanguageServer.RuntimePath);
+function getConfiguredLanguageServerRuntimePath(): string {
+  const languageServerOverride = process.env['DAFNY_LANGUAGE_SERVER'] ?? '';
+  const languageServerSetting = Configuration.get<string | null>(ConfigurationConstants.LanguageServer.RuntimePath) ?? '';
+  return languageServerOverride || languageServerSetting;
 }
 
 function getDafnyPlatformSuffix(): string {
@@ -180,8 +181,7 @@ export class DafnyInstaller {
   }
 
   public isCustomInstallation(): boolean {
-    const configuredLanguageServerRuntimePath = getConfiguredLanguageServerRuntimePath();
-    return configuredLanguageServerRuntimePath != null && configuredLanguageServerRuntimePath !== '';
+    return getConfiguredLanguageServerRuntimePath() !== '';
   }
 
   public async isLanguageServerRuntimeAccessible(): Promise<boolean> {

--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -10,7 +10,7 @@ const GhostDecoration: DecorationRenderOptions = {
     backgroundColor: '#64646480'
   },
   light: {
-    backgroundColor: '#79797980'
+    backgroundColor: '#D3D3D380'
   }
 };
 


### PR DESCRIPTION
### Changes
- Enable starting the extension with a custom language server using an environment variable, which is useful for development scenarios. You can imagine having a make target in the Dafny repository that starts VSCode with the language server from the repository: `DAFNY_LANGUAGE_SERVER=./Binaries/DafnyLanguageServer.dll code`.
- Split the launch configuration "Run Extension" into "Run with default server" and "Run with $DAFNY_LANGUAGE_SERVER"
- Small update to `checkSupportedDotnetVersion` so it's agnostic to symlinks.

### Testing
Manually tested both features

