### PR TITLE
Add DAFNY_DEV_SERVER variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,18 +15,18 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],
-      "env": {
-        "DAFNY_LANGUAGE_SERVER": "",
-      },
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
-      "name": "Run with $DAFNY_LANGUAGE_SERVER",
+      "name": "Run with $DAFNY_DEV_SERVER",
       "type": "extensionHost",
       "request": "launch",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
+      "env": {
+        "DAFNY_SERVER_OVERRIDE": "${env:DAFNY_DEV_SERVER}",
+      },
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -58,9 +58,9 @@ export function getLanguageServerRuntimePath(context: ExtensionContext): string 
 }
 
 function getConfiguredLanguageServerRuntimePath(): string {
-  const languageServerOverride = process.env['DAFNY_LANGUAGE_SERVER'] ?? '';
+  const languageServerOverride = process.env['DAFNY_SERVER_OVERRIDE'] ?? '';
   if(languageServerOverride) {
-    window.showInformationMessage(`Using $DAFNY_LANGUAGE_SERVER = ${languageServerOverride} for the server path`);
+    window.showInformationMessage(`Using $DAFNY_SERVER_OVERRIDE = ${languageServerOverride} for the server path`);
   }
   const languageServerSetting = Configuration.get<string | null>(ConfigurationConstants.LanguageServer.RuntimePath) ?? '';
   return languageServerOverride || languageServerSetting;


### PR DESCRIPTION
Allow configuring a `DAFNY_DEV_SERVER` env variable that's only used when starting the Dafny VSCode extension from source, but not when starting a regular VSCode instance.