### PR TITLE
Added missing status messages.

### DIFF
--- a/src/language/api/compilationStatus.ts
+++ b/src/language/api/compilationStatus.ts
@@ -1,9 +1,8 @@
 import { DocumentUri, integer } from 'vscode-languageclient';
 
 export enum CompilationStatus {
-  ParsingStarted = 'ParsingStarted',
-  ParsingFailed = 'ParsingFailed',
   ResolutionStarted = 'ResolutionStarted',
+  ParsingFailed = 'ParsingFailed',
   ResolutionFailed = 'ResolutionFailed',
   CompilationSucceeded = 'CompilationSucceeded',
   VerificationStarted = 'VerificationStarted',

--- a/src/language/api/compilationStatus.ts
+++ b/src/language/api/compilationStatus.ts
@@ -1,7 +1,9 @@
 import { DocumentUri, integer } from 'vscode-languageclient';
 
 export enum CompilationStatus {
+  ParsingStarted = 'ParsingStarted',
   ParsingFailed = 'ParsingFailed',
+  ResolutionStarted = 'ResolutionStarted',
   ResolutionFailed = 'ResolutionFailed',
   CompilationSucceeded = 'CompilationSucceeded',
   VerificationStarted = 'VerificationStarted',

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -9,12 +9,10 @@ const StatusBarPriority = 10;
 
 function toStatusMessage(status: CompilationStatus, message?: string | null): string {
   switch(status) {
-  case CompilationStatus.ParsingStarted:
-    return Messages.CompilationStatus.ParsingStarted;
-  case CompilationStatus.ParsingFailed:
-    return Messages.CompilationStatus.ParsingFailed;
   case CompilationStatus.ResolutionStarted:
     return Messages.CompilationStatus.ResolutionStarted;
+  case CompilationStatus.ParsingFailed:
+    return Messages.CompilationStatus.ParsingFailed;
   case CompilationStatus.ResolutionFailed:
     return Messages.CompilationStatus.ResolutionFailed;
   case CompilationStatus.CompilationSucceeded:

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -9,8 +9,12 @@ const StatusBarPriority = 10;
 
 function toStatusMessage(status: CompilationStatus, message?: string | null): string {
   switch(status) {
+  case CompilationStatus.ParsingStarted:
+    return Messages.CompilationStatus.ParsingStarted;
   case CompilationStatus.ParsingFailed:
     return Messages.CompilationStatus.ParsingFailed;
+  case CompilationStatus.ResolutionStarted:
+    return Messages.CompilationStatus.ResolutionStarted;
   case CompilationStatus.ResolutionFailed:
     return Messages.CompilationStatus.ResolutionFailed;
   case CompilationStatus.CompilationSucceeded:

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -1,8 +1,7 @@
 export namespace Messages {
   export namespace CompilationStatus {
-    export const ParsingStarted = '$(sync~spin) Parsing Started';
+    export const ResolutionStarted = '$(sync~spin) Resolving...';
     export const ParsingFailed = '$(thumbsdown) Parsing Failed';
-    export const ResolutionStarted = '$(sync~spin) Resolution Started';
     export const ResolutionFailed = '$(thumbsdown) Resolution Failed';
     export const CompilationSucceeded = '$(book) Resolved (not verified)';
     export const Verifying = '$(sync~spin) Verifying';

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -1,6 +1,8 @@
 export namespace Messages {
   export namespace CompilationStatus {
+    export const ParsingStarted = '$(sync~spin) Parsing Started';
     export const ParsingFailed = '$(thumbsdown) Parsing Failed';
+    export const ResolutionStarted = '$(sync~spin) Resolution Started';
     export const ResolutionFailed = '$(thumbsdown) Resolution Failed';
     export const CompilationSucceeded = '$(book) Resolved (not verified)';
     export const Verifying = '$(sync~spin) Verifying';


### PR DESCRIPTION
Fixes #174 but will need Dafny Language Server to support those messages afterwards.

Alternative to discuss:
* Should we replace "Parsing started" with "Resolution started" and remove the second "Resolution started" message?
