### PR TITLE
Avoid downloading dmg when build from source & fix Java recognition

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -166,8 +166,8 @@ export class DafnyInstaller {
     }
     try {
       const process = await this.execLog('javac -version');
-      if(!(/javac \d+\.\d+/.exec(process.stdout)) &&
-         !(/javac \d+\.\d+/.exec(process.stderr))) {
+      if(!(/javac \d+\.\d+/.exec(process.stdout))
+         && !(/javac \d+\.\d+/.exec(process.stderr))) {
         throw '';
       }
     } catch(error: unknown) {
@@ -192,7 +192,7 @@ export class DafnyInstaller {
     await this.execLog(`unzip ${z3filenameOsx}.zip`);
     await this.execLog(`mv ${z3filenameOsx} z3`);
     processChdir(this.getInstallationPath().fsPath);
-    await this.execLog(`mkdir -p ./dafny/`);
+    await this.execLog('mkdir -p ./dafny/');
     await this.execLog(`cp -R ${binaries}/* ./dafny/`);
     processChdir(previousDirectory);
     return true;

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -121,7 +121,7 @@ export class DafnyInstaller {
       await this.cleanInstallDir();
       if(os.type() === 'Darwin' && os.arch() !== 'x64') {
         // Need to build from source and move all files from Binary/ to the out/resource folder
-        this.writeStatus(`Found a non-supported architecture OSX:${os.arch()}. Going to install from source and replace the automated installation.`);
+        this.writeStatus(`Found a non-supported architecture OSX:${os.arch()}. Going to install from source.`);
         return await this.installFromSource();
       } else {
         const archive = await this.downloadArchive(getDafnyDownloadAddress());


### PR DESCRIPTION
Note that previously, Java recognition is done by testing `stdout`. I know for sure that this doesn't work on my system, as it should test `stderr` instead. However, I also do not know how other systems are. So I conservatively tested both, just to be safe.

Fixes #180, #182

cc: @MikaelMayer and @prvshah51 