### PR TITLE
Syntax highlighting after "var" fixed

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,12 @@
+// Issue #230
+module A {
+  trait T {
+    var x: int
+    var y: int
+    //^var should be highlighted correctly, and int should be a type.
+  }
+}
+
 // Issue #221
 method Test() {
   var list: List<A> := new C<A>();

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -26,15 +26,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>:=|:\||;|(?=const|least|greatest|predicate|function|method|lemma|var|type|datatype|newtype)</string>
-			<!--key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.dafny</string>
-				</dict>
-			</dict-->
+			<string>:=|:\||;|\)|\}|(?=(?:class|codatatype|const|constructor|datatype|function|greatest|iterator|least|lemma|method|module|newtype|predicate|trait|type|var)\b)</string>
 			<key>name</key>
 			<string>meta.vardecl.dafny</string>
 			<key>patterns</key>
@@ -150,7 +142,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=&lt;|\s*|,|\)|\}|requires|ensures|modifies|var|const|method|function|datatype|type|newtype|lemma|least|greatest|predicate)</string>
+			<string>(?=&lt;|\s*|,|\)|\}|(?:requires|ensures|modifies|reads|class|codatatype|const|constructor|datatype|function|greatest|iterator|least|lemma|method|module|newtype|predicate|trait|type|var)\b))</string>
 		</dict>
 		<key>genericfunctioncalls</key>
 		<dict>

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -26,17 +26,17 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>:=|:\||;</string>
-			<key>endCaptures</key>
+			<string>:=|:\||;|(?=const|least|greatest|predicate|function|method|lemma|var|type|datatype|newtype)</string>
+			<!--key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>storage.type.dafny</string>
 				</dict>
-			</dict>
+			</dict-->
 			<key>name</key>
-			<string>meta.class.identifier.dafny</string>
+			<string>meta.vardecl.dafny</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -54,6 +54,10 @@
 				<dict>
 					<key>include</key>
 					<string>#generics</string>
+				</dict>
+			  <dict>
+				  <key>include</key>
+				  <string>#formalTypeDeclaration</string>
 				</dict>
 			</array>
 		</dict>
@@ -131,6 +135,23 @@
 	</array>
 	<key>repository</key>
 	<dict>
+	  <key>formalTypeDeclaration</key>
+		<dict>
+			<key>name</key>
+			<string>meta.type.formaldeclaration</string>
+			<key>begin</key>
+			<string>(?<!\{|:):\s*(?:[\w'?]+\.)*([\w'?]+\b(?!&lt;))</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.dafny</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?=&lt;|\s*|,|\)|\}|requires|ensures|modifies|var|const|method|function|datatype|type|newtype|lemma|least|greatest|predicate)</string>
+		</dict>
 		<key>genericfunctioncalls</key>
 		<dict>
 			<key>begin</key>
@@ -529,20 +550,8 @@
 					</array>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>(?<!\{|:):\s*(?:[\w'?]+\.)*([\w'?]+\b(?!&lt;))</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.dafny</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(?=&lt;|\s*|,|\)|\}|requires|ensures|modifies)</string>
-					<key>name</key>
-					<string>meta.type.formaldeclaration</string>
+				  <key>include</key>
+					<string>#formalTypeDeclaration</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
The issue is that the syntax highlighter was expecting "var" to be followed by a semicolon ";". If not, it would never exit the fact that it's a "var" declaration and would not highlight anything else.
I added a few keywords and ensured that the type after the var is highlighted as a type as well.
Now:

![image](https://user-images.githubusercontent.com/3601079/181823978-1e179f08-b5ab-408b-9c1c-cf7f4adc7afd.png)


Fixes #230