### PR TITLE
Ensure gutter icons show up in the correct locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "dafny.displayVerificationAsTests": {
           "type": "boolean",
           "default": "true",
-          "description": "Display verification status in the test panel (requires restart and Dafny 3.8.0+)"
+          "description": "Display verification status both in the test panel, and as actionable buttons next to top-level symbols in the editor (requires restart and Dafny 3.8.0+)"
         },
         "dafny.dafnyPlugins": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -160,6 +160,11 @@
           "default": "true",
           "description": "Display verification status in the gutter (requires restart and Dafny 3.7.0+)"
         },
+        "dafny.displayVerifiableSymbols": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Display verification status in the test panel (requires restart and Dafny 3.8.0+)"
+        },
         "dafny.dafnyPlugins": {
           "type": "array",
           "items": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
           "default": "true",
           "description": "Display verification status in the gutter (requires restart and Dafny 3.7.0+)"
         },
-        "dafny.displayVerifiableSymbols": {
+        "dafny.displayVerificationAsTests": {
           "type": "boolean",
           "default": "true",
           "description": "Display verification status in the test panel (requires restart and Dafny 3.8.0+)"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@ export namespace ConfigurationConstants {
     export const MarkGhostStatements = 'markGhostStatements';
     export const DafnyPlugins = 'dafnyPlugins';
     export const DisplayGutterStatus = 'displayGutterStatus';
+    export const DisplayVerifiableSymbols = 'displayVerifiableSymbols';
   }
 
   export namespace Compiler {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export namespace ConfigurationConstants {
     export const MarkGhostStatements = 'markGhostStatements';
     export const DafnyPlugins = 'dafnyPlugins';
     export const DisplayGutterStatus = 'displayGutterStatus';
-    export const DisplayVerifiableSymbols = 'displayVerifiableSymbols';
+    export const DisplayVerificationAsTests = 'displayVerificationAsTests';
   }
 
   export namespace Compiler {

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -9,6 +9,8 @@ import GhostDiagnosticsView from './ghostDiagnosticsView';
 import VerificationGutterStatusView from './verificationGutterStatusView';
 import RelatedErrorView from './relatedErrorView';
 import VerificationSymbolStatusView from './verificationSymbolStatusView';
+import Configuration from '../configuration';
+import { ConfigurationConstants } from '../constants';
 
 export default async function createAndRegisterDafnyIntegration(
   context: ExtensionContext,
@@ -20,7 +22,7 @@ export default async function createAndRegisterDafnyIntegration(
   const compilationStatusView = CompilationStatusView.createAndRegister(context, languageClient, languageServerVersion);
   let symbolStatusView: VerificationSymbolStatusView | undefined = undefined;
   const serverSupportsSymbolStatusView = versionToNumeric('3.8.0') <= versionToNumeric(languageServerVersion);
-  if(serverSupportsSymbolStatusView) {
+  if(serverSupportsSymbolStatusView && Configuration.get<string>(ConfigurationConstants.LanguageServer.DisplayVerifiableSymbols)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(context, languageClient, compilationStatusView);
   } else {
     compilationStatusView.registerBefore38Messages();

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -22,7 +22,7 @@ export default async function createAndRegisterDafnyIntegration(
   const compilationStatusView = CompilationStatusView.createAndRegister(context, languageClient, languageServerVersion);
   let symbolStatusView: VerificationSymbolStatusView | undefined = undefined;
   const serverSupportsSymbolStatusView = versionToNumeric('3.8.0') <= versionToNumeric(languageServerVersion);
-  if(serverSupportsSymbolStatusView && Configuration.get<string>(ConfigurationConstants.LanguageServer.DisplayVerifiableSymbols)) {
+  if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(context, languageClient, compilationStatusView);
   } else {
     compilationStatusView.registerBefore38Messages();

--- a/src/ui/verificationGutterStatusView.ts
+++ b/src/ui/verificationGutterStatusView.ts
@@ -261,7 +261,7 @@ export default class VerificationGutterStatusView {
   private async getRangesOfLineStatus(params: IVerificationGutterStatusParams): Promise<Map<LineVerificationStatus, Range[]>> {
     const perLineStatus = this.addCosmetics(params.perLineStatus);
 
-    const symbolParams = (await this.symbolStatusView?.getFirstStatusForCurrentVersion(params.uri)) ?? [];
+    const symbolParams = (await this.symbolStatusView?.getVerifiableRanges(params.uri)) ?? [];
     const originalLinesToSkip = symbolParams.map(range => range.start.line).sort((a, b) => a - b);
 
     return VerificationGutterStatusView.perLineStatusToRanges(perLineStatus, originalLinesToSkip);

--- a/src/ui/verificationGutterStatusView.ts
+++ b/src/ui/verificationGutterStatusView.ts
@@ -262,7 +262,7 @@ export default class VerificationGutterStatusView {
     const perLineStatus = this.addCosmetics(params.perLineStatus);
 
     const symbolParams = (await this.symbolStatusView?.getFirstStatusForCurrentVersion(params.uri)) ?? [];
-    const originalLinesToSkip = symbolParams.map(testItem => testItem.range!.start.line).sort((a, b) => a - b);
+    const originalLinesToSkip = symbolParams.map(range => range.start.line).sort((a, b) => a - b);
 
     return VerificationGutterStatusView.perLineStatusToRanges(perLineStatus, originalLinesToSkip);
   }

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -20,8 +20,7 @@ export function createAndRegister(
   context: ExtensionContext,
   languageClient: DafnyLanguageClient,
   compilationStatusView: CompilationStatusView): VerificationSymbolStatusView {
-  const instance = new VerificationSymbolStatusView(context, languageClient, compilationStatusView);
-  return instance;
+  return new VerificationSymbolStatusView(context, languageClient, compilationStatusView);
 }
 
 /**
@@ -29,46 +28,11 @@ export function createAndRegister(
  */
 export default class VerificationSymbolStatusView {
 
-  public getFirstStatusForCurrentVersion(uriString: string): Promise<Range[]> {
-    return this.getItemsFilePromise(uriString).promise;
-  }
-
   public static createAndRegister(
     context: ExtensionContext,
     languageClient: DafnyLanguageClient,
     compilationStatusView: CompilationStatusView): VerificationSymbolStatusView {
-    const instance = new VerificationSymbolStatusView(context, languageClient, compilationStatusView);
-    window.onDidChangeActiveTextEditor(e => {
-      if(e !== undefined) {
-        const lastUpdate = instance.updatesPerFile.get(e.document.uri.toString());
-        if(lastUpdate !== undefined) {
-          instance.update(lastUpdate);
-        }
-      }
-    });
-    workspace.onDidChangeTextDocument(e => {
-      const uriString = e.document.uri.toString();
-      instance.updatesPerFile.delete(uriString);
-      instance.updateListenersPerFile.delete(uriString);
-    });
-    context.subscriptions.push(
-      languageClient.onVerificationSymbolStatus(params => instance.update(params)),
-      languageClient.onCompilationStatus(params => compilationStatusView.compilationStatusChangedForBefore38(params))
-    );
-    return instance;
-  }
-
-  private getItemsFilePromise(uriString: string): ResolveablePromise<Range[]> {
-    let listener = this.updateListenersPerFile.get(uriString);
-    if(listener === undefined) {
-      let storedResolve: (value: Range[]) => void;
-      const promise = new Promise<Range[]>((resolve) => {
-        storedResolve = resolve;
-      });
-      listener = { resolve: storedResolve!, promise };
-      this.updateListenersPerFile.set(uriString, listener);
-    }
-    return listener;
+    return new VerificationSymbolStatusView(context, languageClient, compilationStatusView);
   }
 
   public constructor(
@@ -78,18 +42,28 @@ export default class VerificationSymbolStatusView {
     this.controller = this.createController();
     context.subscriptions.push(this.controller);
 
+    window.onDidChangeActiveTextEditor(e => {
+      if(e !== undefined) {
+        const lastUpdate = this.updatesPerFile.get(e.document.uri.toString());
+        if(lastUpdate !== undefined) {
+          this.update(lastUpdate);
+        }
+      }
+    }, this, context.subscriptions);
     workspace.onDidChangeTextDocument(e => {
+      console.log('document updated to', e.document.version);
       const uriString = e.document.uri.toString();
       this.updateListenersPerFile.delete(uriString);
-    });
+      this.updatesPerFile.delete(uriString);
+    }, this, context.subscriptions);
     workspace.onDidCloseTextDocument(e => {
       const uriString = e.uri.toString();
       this.updatesPerFile.delete(uriString);
-    });
+    }, this, context.subscriptions);
     context.subscriptions.push(
-      languageClient.onVerificationSymbolStatus(params => this.update(params))
+      languageClient.onVerificationSymbolStatus(params => this.update(params)),
+      languageClient.onCompilationStatus(params => compilationStatusView.compilationStatusChangedForBefore38(params))
     );
-
     window.onDidChangeActiveTextEditor(e => {
       if(e !== undefined) {
         const lastUpdate = this.updatesPerFile.get(e.document.uri.toString());
@@ -107,7 +81,7 @@ export default class VerificationSymbolStatusView {
   private readonly updatesPerFile: Map<string, IVerificationSymbolStatusParams> = new Map();
   private readonly controller: TestController;
   private automaticRunEnd: boolean = false;
-  private processUpdateLock: Promise<void> = Promise.resolve();
+  private noRunCreationInProgress: Promise<void> = Promise.resolve();
 
   private createController(): TestController {
     const controller = tests.createTestController('verificationStatus', 'Verification Status');
@@ -115,8 +89,8 @@ export default class VerificationSymbolStatusView {
       const items: TestItem[] = this.getItemsInRun(request, controller);
       const runningItems: TestItem[] = [];
       let outerResolve: () => void;
-      await this.processUpdateLock;
-      this.processUpdateLock = new Promise((resolve) => {
+      await this.noRunCreationInProgress;
+      this.noRunCreationInProgress = new Promise((resolve) => {
         outerResolve = resolve;
       });
 
@@ -176,24 +150,31 @@ export default class VerificationSymbolStatusView {
 
   private async update(params: IVerificationSymbolStatusParams): Promise<void> {
     this.getItemsFilePromise(params.uri).resolve(params.namedVerifiables.map(v => VerificationSymbolStatusView.convertRange(v.nameRange)));
+    await this.noRunCreationInProgress;
     const uri = Uri.parse(params.uri);
     const document = await workspace.openTextDocument(uri);
+    const rootSymbols = await commands.executeCommand('vscode.executeDocumentSymbolProvider', uri) as DocumentSymbol[] | undefined;
+
+    // After this check we may no longer use awaits, because they allow the document to be updated and then our update becomes outdated.
     if(params.version !== document.version) {
       return;
     }
+    this.updateForSpecificDocumentVersion(params, document, rootSymbols);
+  }
 
-    await this.processUpdateLock;
+  private updateForSpecificDocumentVersion(params: IVerificationSymbolStatusParams,
+    document: TextDocument,
+    rootSymbols: DocumentSymbol[] | undefined) {
 
     this.updateStatusBar(params);
     this.updatesPerFile.set(params.uri, params);
     const controller = this.controller;
-    const rootSymbols: DocumentSymbol[] = await commands.executeCommand('vscode.executeDocumentSymbolProvider', uri) as DocumentSymbol[];
     let items: TestItem[];
     if(rootSymbols !== undefined) {
       items = this.updateUsingSymbols(params, document, controller, rootSymbols);
     } else {
       items = params.namedVerifiables.map(f => this.getItem(document,
-        VerificationSymbolStatusView.convertRange(f.nameRange), controller, uri));
+        VerificationSymbolStatusView.convertRange(f.nameRange), controller, document.uri));
       controller.items.replace(items);
     }
 
@@ -351,5 +332,22 @@ export default class VerificationSymbolStatusView {
 
   private static convertPosition(position: lspPosition): Position {
     return new Position(position.line, position.character);
+  }
+
+  public getFirstStatusForCurrentVersion(uriString: string): Promise<Range[]> {
+    return this.getItemsFilePromise(uriString).promise;
+  }
+
+  private getItemsFilePromise(uriString: string): ResolveablePromise<Range[]> {
+    let listener = this.updateListenersPerFile.get(uriString);
+    if(listener === undefined) {
+      let storedResolve: (value: Range[]) => void;
+      const promise = new Promise<Range[]>((resolve) => {
+        storedResolve = resolve;
+      });
+      listener = { resolve: storedResolve!, promise };
+      this.updateListenersPerFile.set(uriString, listener);
+    }
+    return listener;
   }
 }

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -149,7 +149,6 @@ export default class VerificationSymbolStatusView {
   }
 
   private async update(params: IVerificationSymbolStatusParams): Promise<void> {
-    this.getItemsFilePromise(params.uri).resolve(params.namedVerifiables.map(v => VerificationSymbolStatusView.convertRange(v.nameRange)));
     await this.noRunCreationInProgress;
     const uri = Uri.parse(params.uri);
     const document = await workspace.openTextDocument(uri);
@@ -166,6 +165,7 @@ export default class VerificationSymbolStatusView {
     document: TextDocument,
     rootSymbols: DocumentSymbol[] | undefined) {
 
+    this.getVerifiableRangesPromise(params.uri).resolve(params.namedVerifiables.map(v => VerificationSymbolStatusView.convertRange(v.nameRange)));
     this.updateStatusBar(params);
     this.updatesPerFile.set(params.uri, params);
     const controller = this.controller;
@@ -334,11 +334,11 @@ export default class VerificationSymbolStatusView {
     return new Position(position.line, position.character);
   }
 
-  public getFirstStatusForCurrentVersion(uriString: string): Promise<Range[]> {
-    return this.getItemsFilePromise(uriString).promise;
+  public getVerifiableRanges(uriString: string): Promise<Range[]> {
+    return this.getVerifiableRangesPromise(uriString).promise;
   }
 
-  private getItemsFilePromise(uriString: string): ResolveablePromise<Range[]> {
+  private getVerifiableRangesPromise(uriString: string): ResolveablePromise<Range[]> {
     let listener = this.updateListenersPerFile.get(uriString);
     if(listener === undefined) {
       let storedResolve: (value: Range[]) => void;


### PR DESCRIPTION
Fixes https://github.com/dafny-lang/ide-vscode/issues/237
Fixes https://github.com/dafny-lang/ide-vscode/issues/235

### Changes
- Add a version check to prevent processing out-of-date symbolStatus updates
- Enable turning verification status in the test panel on/off

### Caveats
If you hold the enter key to continuously insert newlines, the 'play' icon from the verification symbol status still lags behind the moving text. I've tried to find whether it applies outdated data, but everything checks out, so I'm very confused as to while the visuals don't.