### PR TITLE
Prevent overlap of play and gutter icons on parent nodes

### DIFF
--- a/src/test/suite/verificationSymbolStatusView.test.ts
+++ b/src/test/suite/verificationSymbolStatusView.test.ts
@@ -73,7 +73,7 @@ suite('Verification symbol view', () => {
       const replacedItems = await toPromise(listener.replaceCalled.event);
       assert.strictEqual(replacedItems.length, 0);
       const runRequest = await testRunCalledPromise;
-      assert.strictEqual(runRequest.include?.length, 4);
+      assert.strictEqual(runRequest.include?.length, 4, JSON.stringify(runRequest.include));
       await testRunEndPromise;
     } finally {
       vscode.commands.executeCommand = originalExecuteCommand;

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -178,14 +178,14 @@ export default class VerificationSymbolStatusView {
         VerificationSymbolStatusView.convertRange(f.nameRange), controller, document.uri));
       controller.items.replace(leafItems);
     }
-    function collectTestItems(collection: TestItemCollection, result: TestItem[]) {
+    const allTestItems: TestItem[] = [];
+    function collectTestItems(collection: TestItemCollection) {
       collection.forEach(item => {
-        result.push(item);
-        collectTestItems(item.children, result);
+        allTestItems.push(item);
+        collectTestItems(item.children);
       });
     }
-    const allTestItems: TestItem[] = [];
-    collectTestItems(controller.items, allTestItems);
+    collectTestItems(controller.items);
     this.getVerifiableRangesPromise(params.uri).resolve(allTestItems.map(v => v.range!));
 
     const runningItemsWithoutRun = params.namedVerifiables.

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -193,7 +193,9 @@ export default class VerificationSymbolStatusView {
         return { verifiable: element, testItem: leafItems[index] };
       }).
       filter(({ verifiable, testItem }) => {
-        return this.itemStates.get(testItem.id) !== verifiable.status && this.itemRuns.get(testItem.id) === undefined;
+        return this.itemStates.get(testItem.id) !== verifiable.status
+          && (this.itemRuns.get(testItem.id) === undefined
+            || this.itemRuns.get(testItem.id)?.run.token.isCancellationRequested);
       }).map(r => r.testItem);
     if(runningItemsWithoutRun.length > 0) {
       this.createRun(runningItemsWithoutRun);


### PR DESCRIPTION
### Changes

- Prevent overlap of play and gutter icons on parent nodes such as classes and modules.
- Prevent visible and internal state of testItems from getting out of sync, which could occur when cancelling a run while it was returning results.

### Testing

Manually tested