### PR TITLE
Fix highlighting of labelled statements

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,19 @@
+// Issue #240
+method Test(someVar: int)
+  requires zero: someVar > 0
+              // ^^^^^^^ should not look like a type (the int above)
+{
+    label before: otherMethod();
+               // ^^^^^^^^^^^ should not look like a type
+    assert notzero: someVar != 0 by {
+                 // ^^^^^^^ should not look like a type
+        reveal zero;
+    }
+}
+
+method otherMethod() {
+}
+
 // Issue #230
 module A {
   trait T {

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -132,7 +132,7 @@
 			<key>name</key>
 			<string>meta.type.formaldeclaration</string>
 			<key>begin</key>
-			<string>(?<!\{|:):\s*(?:[\w'?]+\.)*([\w'?]+\b(?!&lt;))</string>
+			<string>(?<!\{|:|(?:label|assert|requires)\s*[_\w]+):\s*(?:[\w'?]+\.)*([\w'?]+\b(?!&lt;))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This PR fixes #240 by checking that the ":" is not preceeded by "label <ident>", "assert <indent>" and "requires <indent>", so that its right-hand side is not misinterpreted as a type.