### PR TITLE
Fix: Number followed by `<` incorrectly highlighted as a generic

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,12 @@
+// Issue #269
+method SpaceAFterOperator(n: nat)
+  requires 1<n
+  // this should be a comment and ensures should be the same color as requires
+  ensures true
+{
+  assert 1<(2+2);
+}
+
 // Issue #240
 method Test(someVar: int)
   requires zero: someVar > 0

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -147,7 +147,7 @@
 		<key>genericfunctioncalls</key>
 		<dict>
 			<key>begin</key>
-			<string>([\w'?]+)\s*&lt;(?=[^\)\(]*&gt;(?=\())</string>
+			<string>([a-zA-Z'?][\w'?]*)\s*&lt;(?=[^\)\(]*&gt;(?=\())</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -577,7 +577,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>([\w'?]+)&lt;(?=[\w'?]+)</string>
+					<string>([a-zA-Z][\w'?]*)&lt;(?=[\w'?]+)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Change the highlight grammar and added a test to fix #269

Now:
![image](https://user-images.githubusercontent.com/3601079/191332904-678b6f28-73cd-4e35-aa21-54546da011c2.png)
