### PR TITLE
Release v2.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 2.8.5
+- Fix: Make brew update optional (https://github.com/dafny-lang/ide-vscode/pull/284)
+
 ## 2.8.4
 - Updating LanguageServerConstants.LatestVersion value to the latest version number 3.9.0. (https://github.com/dafny-lang/ide-vscode/pull/280)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ide-vscode",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ide-vscode",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "publisher": "dafny-lang",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Making `brew update` optional is critical for some of our users, so I would not delay publishing this update.