### PR TITLE
Only require Java to be installed when using a Dafny version before 3.9

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -235,7 +235,7 @@ export class DafnyInstaller {
     processChdir(Utils.joinPath(installationPath, 'dafny').fsPath);
     await this.execLog('git fetch --all --tags');
     await this.execLog(`git checkout v${configuredVersion}`);
-    await this.execLog('make exe');
+    await this.execLog('dotnet build Source/DafnyLanguageServer/DafnyLanguageServer.csproj');
     const binaries = Utils.joinPath(installationPath, 'dafny', 'Binaries').fsPath;
     processChdir(binaries);
     try {

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -2,6 +2,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
+import { versionToNumeric } from '../ui/dafnyIntegration';
 
 import { workspace, ExtensionContext, Uri, OutputChannel, FileSystemError, window } from 'vscode';
 import { Utils } from 'vscode-uri';
@@ -212,24 +213,28 @@ export class DafnyInstaller {
       and restart VSCode, which may reinstall Dafny.`);
       return false;
     }
-    try {
-      const process = await this.execLog('javac -version');
-      if(!(/javac \d+\.\d+/.exec(process.stdout))
-         && !(/javac \d+\.\d+/.exec(process.stderr))) {
-        throw '';
+    const configuredVersion = await getConfiguredVersion(this.context);
+    if(versionToNumeric(configuredVersion) < versionToNumeric('3.9.0')) {
+      try {
+
+        const process = await this.execLog('javac -version');
+        if(!(/javac \d+\.\d+/.exec(process.stdout))
+          && !(/javac \d+\.\d+/.exec(process.stderr))) {
+          throw '';
+        }
+      } catch(error: unknown) {
+        const errorMsg = error === '' ? 'Javac not found' : `${error}`;
+        this.writeStatus(`${errorMsg}. Please install a valid JDK`
+        + ' and ensure that the path containing javac is in the PATH environment variable. '
+        + 'You can obtain a free open-source JDK 1.8 from here: '
+        + 'https://aws.amazon.com/corretto/');
+        return false;
       }
-    } catch(error: unknown) {
-      const errorMsg = error === '' ? 'Javac not found' : `${error}`;
-      this.writeStatus(`${errorMsg}. Please install a valid JDK`
-       + ' and ensure that the path containing javac is in the PATH environment variable. '
-       + 'You can obtain a free open-source JDK 1.8 from here: '
-       + 'https://aws.amazon.com/corretto/');
-      return false;
     }
     await this.execLog(`git clone --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);
     processChdir(Utils.joinPath(installationPath, 'dafny').fsPath);
     await this.execLog('git fetch --all --tags');
-    await this.execLog(`git checkout v${await getConfiguredVersion(this.context)}`);
+    await this.execLog(`git checkout v${configuredVersion}`);
     await this.execLog('make exe');
     const binaries = Utils.joinPath(installationPath, 'dafny', 'Binaries').fsPath;
     processChdir(binaries);

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -224,7 +224,7 @@ export class DafnyInstaller {
         }
       } catch(error: unknown) {
         const errorMsg = error === '' ? 'Javac not found' : `${error}`;
-        this.writeStatus(`${errorMsg}. Please install a valid JDK`
+        this.writeStatus(`${errorMsg}. Javac is needed because you use a version of Dafny older than 3.9.0. Please install a valid JDK`
         + ' and ensure that the path containing javac is in the PATH environment variable. '
         + 'You can obtain a free open-source JDK 1.8 from here: '
         + 'https://aws.amazon.com/corretto/');

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -37,7 +37,7 @@ export default async function createAndRegisterDafnyIntegration(
   await DafnyVersionView.createAndRegister(context, languageServerVersion);
 }
 
-function versionToNumeric(version: string): number {
+export function versionToNumeric(version: string): number {
   const numbers = version.split('.').map(x => Number.parseInt(x));
   return ((numbers[0] * 1000) + numbers[1]) * 1000 + numbers[2];
 }


### PR DESCRIPTION
### Changes

- Only build the language server when building Dafny from source for the IDE
- The Dafny language server 3.9 does not require Java to be build, so the Java check can be removed for version 3.9 and up

### Testing

Ran this on a M1 mac where previously Java could not be found from the VSCode Dafny plugin, and now it built from from source correctly.