### PR TITLE
fix: `dafny.dotnetExecutablePath` works to install custom source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 .DS_Store
 /dist/*
 !/dist/.gitkeep
+/.history
+*.vsix

--- a/README.md
+++ b/README.md
@@ -138,16 +138,10 @@ Because the latest version of the plugin requires recent changes to the Dafny la
 
 ### Packaging
 
-To create a VSIX package of the previously built sources, install the [VSCode Extension Manager](https://github.com/microsoft/vscode-vsce) globally:
+To create a VSIX package of the previously built sources, create the package through the CLI:
 
 ```sh
-npm install -g vsce
-```
-
-Now create the package through the CLI:
-
-```sh
-vsce package
+npx vsce package
 ```
 
 ### Coding Conventions

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -16,7 +16,7 @@ import { exec } from 'child_process';
 import { chdir as processChdir, cwd as processCwd } from 'process';
 import fetch from 'cross-fetch';
 
-import {checkSupportedDotnetVersion, getDotnetExecutablePath} from '../dotnet'
+import { checkSupportedDotnetVersion, getDotnetExecutablePath } from '../dotnet';
 
 const execAsync = promisify(exec);
 
@@ -249,7 +249,7 @@ export class DafnyInstaller {
     // it MAY NOT be on the path.
     // This will cause the build to fail.
     // This works around this edge case.
-    const injectPath = `PATH=${path.dirname(dotnet)}:$PATH`
+    const injectPath = `PATH=${path.dirname(dotnet)}:$PATH`;
     // Build the DafnyLanguageServer
     await this.execLog(`${injectPath} ${ (await getDotnetExecutablePath()).path } build Source/DafnyLanguageServer/DafnyLanguageServer.csproj`);
     const binaries = Utils.joinPath(installationPath, 'dafny', 'Binaries').fsPath;


### PR DESCRIPTION
If `dotnet` is installed
and placed in `dafny.dotnetExecutablePath`
custom source should still be able to be built.

To do this `checkSupportedDotnetVersion`
needs to be the primary way to detect `dotnet`.
This has the side effect of both not double installing from `brew` but also not requireing an install if `dotnet` is already installed.

The `wget` call is also removed
since there are already helpers to perform this get and unzip. They are updated to take a `thing` to facilitate logging. There is also a bit of update to the `Z3` section
to account for this change.

The largest issue with this was
`Source/DafnyCore/DafnyCore.csproj`
has direct `dotnet` build targets.
This means that call to build will fail
if `dotnet` is not on the `PATH`.
This is unfortunate, but…
So we add it for that specific command.

Finnaly, speed up the `git clone`
to both checkout the tag and not get history.

Added a few things to `.gitignore`
and simplified the ReadMe’s use of `vsce`