### PR TITLE
Allow copying counterexamples to the clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
       },
       {
         "command": "dafny.copyCounterexamples",
-        "title": "Dafny: Copy All Counterexamples to Clipboard"
+        "title": "Dafny: Copy Counterexamples to Clipboard (Experimental)"
       },
       {
         "command": "dafny.restartServer",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
           "when": "editorTextFocus && editorLangId == dafny && !dafny.counterexampleMenu.CanShowCounterExample",
           "command": "dafny.hideCounterexample",
           "group": "7_Dafny@2"
+        },
+        {
+          "when": "editorTextFocus && editorLangId == dafny",
+          "command": "dafny.copyCounterexamples",
+          "group": "7_Dafny@2"
         }
       ]
     },
@@ -260,6 +265,10 @@
       {
         "command": "dafny.hideCounterexample",
         "title": "Dafny: Hide Counterexample"
+      },
+      {
+        "command": "dafny.copyCounterexamples",
+        "title": "Dafny: Copy All Counterexamples to Clipboard"
       },
       {
         "command": "dafny.restartServer",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,6 +4,7 @@ export namespace DafnyCommands {
   export const CompileAndRun = 'dafny.compileAndRun';
   export const ShowCounterexample = 'dafny.showCounterexample';
   export const HideCounterexample = 'dafny.hideCounterexample';
+  export const CopyCounterexamples = 'dafny.copyCounterexamples';
   export const OpenStatusBarMenu = 'dafny.openStatusBarMenu';
   export const RestartServer = 'dafny.restartServer';
 }


### PR DESCRIPTION
This patch adds a new contextual menu option to allow copying the counterexamples received from the language server to the system clipboard.  At present, non-trivial counterexamples are hard to read in the current "everything appears in one line" form.  Additionally, they are difficult to share with colleagues or instructors, inhibiting "rubber-duck" counterexample debugging.  For instance, I have a counterexample that stretches, I'd wager, _twenty to thirty_ screen widths across in a project I'm working on now - honestly I have no idea how to parse it at that point.

I think all parties agree that #52 would go a long way to addressing the former and, depending on how VS code lets users extract state from the debugger, potentially the latter too.  However, this issue hasn't seen any activity since last year.

This patch simply introduces a new contextual menu option to copy counterexamples to the clipboard. 

<img width="818" alt="image" src="https://user-images.githubusercontent.com/8949748/198400383-2856fe95-f34c-421e-814f-e80ae7cfffbd.png">

Currently they get copied in the same order that the language server hands them to us (which is not in line order, but, perhaps it should be?  In the presence of multiple errors, though, seems like one could have collisions, so I'm leaving it like this for now)

Examples of clipboard output might be:

```
At "ensures A.Next(IC(c), I(c, s), I(c, s')) {" (file:///Users/ntaylor/school/smrt/src/BlockDisk.dfy:277):
    c:BlockDisk.Constants = Constants(n__blocks := 4294966632)
    s:BlockDisk.State = State(blocks := @1)
    s':BlockDisk.State = State(blocks := @2)
    block_id:int = 4194663
    val:seq<NativeTypes.uint8> = (Length := 1024)
    aconst:BlockDisk.Constants = ()
    astate:BlockDisk.State = ()
    astate':BlockDisk.State = ()
    byte_off:int = 0
    @1:seq<seq<NativeTypes.uint8>> = (Length := 4294966632, [4194663] := val)
    @2:seq<seq<NativeTypes.uint8>> = (Length := 4294966632)

At "var aconst := IC(c);" (file:///Users/ntaylor/school/smrt/src/BlockDisk.dfy:278):
    c:BlockDisk.Constants = Constants(n__blocks := 4294966632, n__blocks := 4294966632)
    s:BlockDisk.State = State(blocks := @1)
    s':BlockDisk.State = State(blocks := @2)
    block_id:int = 4194663
    val:seq<NativeTypes.uint8> = (Length := 1024)
    aconst:BlockDisk.Constants = c
    astate:BlockDisk.State = ()
    astate':BlockDisk.State = ()
    byte_off:int = 0
    @1:seq<seq<NativeTypes.uint8>> = (Length := 4294966632, [4194663] := val)
    @2:seq<seq<NativeTypes.uint8>> = (Length := 4294966632)
```

It's pretty undecorated - I wanted to leave it essentially in the same form as the extension shows, but with just enough structure to make it more readable.