### PR TITLE
Ghost code more like comments

### DIFF
--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -6,11 +6,12 @@ import { DafnyLanguageClient } from '../language/dafnyLanguageClient';
 import { getVsDocumentPath, toVsRange } from '../tools/vscode';
 
 const GhostDecoration: DecorationRenderOptions = {
+  fontStyle: 'italic',
   dark: {
-    backgroundColor: '#64646480'
+    opacity: '80%'
   },
   light: {
-    backgroundColor: '#D3D3D380'
+    opacity: '70%'
   }
 };
 


### PR DESCRIPTION
We have received the feedback that highlights of ghost code can sometimes be confused for a kind of selection. This PR solves the problem by changing the style of ghost code to be
- Italics: Reminds of comments.
- Opacity: Makes it immediately appearing where the ghost code is or if some ambiguous code is ghost.

## Before:

|        | Dark | Light |
| -----|-------------------|---------------|
| Old, without selection | ![image](https://user-images.githubusercontent.com/3601079/200359643-aecd2397-0a2a-4fb7-b05d-073e0bcdb5ed.png) | ![image](https://user-images.githubusercontent.com/3601079/200359337-48279c06-9bc2-4830-a803-76d8e915ab68.png) |
| Old, with selection | ![image](https://user-images.githubusercontent.com/3601079/200359676-8c496632-d6d8-4456-b6f3-ae0231deff19.png) | ![image](https://user-images.githubusercontent.com/3601079/200359428-4d8d9c55-e06a-4c03-970f-cb9e30807630.png) |
|| **This PR would do the following** ||
| New, without selection | ![image](https://user-images.githubusercontent.com/3601079/200359113-da089c24-1d98-40ff-8c44-5a63d2f8eeef.png) | ![image](https://user-images.githubusercontent.com/3601079/200359164-3ff0d631-fd61-48ad-bc18-06c54a209d97.png) |
[ New, with selection | ![image](https://user-images.githubusercontent.com/3601079/200360010-1632e769-7285-4c35-af5f-cd1fae01e122.png) | ![image](https://user-images.githubusercontent.com/3601079/200360265-a9d9920a-c5a3-4b55-85c9-38dfb64e7378.png) |

These two visual cues would not interfere with text selection at all, are reminiscent of other specifications like in C#, and feel more natural to me.