### PR TITLE
Fix: Ghost highlighting no longer out-of-date

### DIFF
--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -26,6 +26,7 @@ export default class GhostDiagnosticsView {
     context.subscriptions.push(
       workspace.onDidCloseTextDocument(document => instance.clearGhostDiagnostics(document.uri.toString())),
       window.onDidChangeActiveTextEditor(editor => instance.refreshDisplayedGhostDiagnostics(editor)),
+      workspace.onDidChangeTextDocument(() => instance.refreshDisplayedGhostDiagnostics(window.activeTextEditor)),
       languageClient.onGhostDiagnostics(params => instance.updateGhostDiagnostics(params)),
       instance
     );


### PR DESCRIPTION
Fixes https://github.com/dafny-lang/dafny/issues/3041

Implemented @keyboardDrummer 's suggestion to re-render on the client on every edit, rather than sending up-to-date diagnostics (even if unchanged)