### PR TITLE
Support two instances of VSCode without crashing.

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -177,8 +177,8 @@ async function cloneAllNecessaryDlls(configuredPath: string): Promise<string> {
     } catch(e: unknown) {
       console.log(e);
       window.showWarningMessage(
-        'Another process (usually VSCode) prevented Dafny from importing the locally built DafnyLanguageServer.dll.\n'+
-        'This is fine if you did not modify DafnyLanguageServer.dll recently.');
+        'Another process (usually VSCode) prevented Dafny from importing the locally built DafnyLanguageServer.dll.\n'
+        + 'This is fine if you did not modify DafnyLanguageServer.dll recently.');
     }
 
     const newPath = path.join(vscodeDir, `${dlsName}.dll`);

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -163,6 +163,7 @@ async function cloneAllNecessaryDlls(configuredPath: string): Promise<string> {
     fs.rmdirSync(vscodeDir, { recursive: true });
   };
   await ensureDirExists(vscodeDir);
+  process.on('exit', cleanup);
   // Copy all the files from installationDir to vscodeDir
   const files = await fs.promises.readdir(installationDir);
   for(const file of files) {
@@ -188,7 +189,6 @@ async function cloneAllNecessaryDlls(configuredPath: string): Promise<string> {
   }
 
   const newPath = path.join(vscodeDir, dls);
-  process.on('exit', cleanup);
   return newPath;
 }
 


### PR DESCRIPTION
This PR ensures that two instances of VSCode can run Dafny on a locally built DafnyLanguageServer.dll without the second crashing like this
![image](https://user-images.githubusercontent.com/3601079/202772830-10dc05aa-8dcc-49cb-bcc9-7ba8ee72f53e.png)

VSCode will basically detect a custom installation, and copy all the necessary dependencies to a unique temporary folder. This enables that:
- Developers writing Dafny code can also continuously compile the DLLs without having an error that the DLL are being used, e.g. they can also run tests in their IDE.
- There can be multiple instances of VSCode running.
- Reloading VSCode always copies the files again, so one can simply reload VSCode after compiling the language server.
