### PR TITLE
Always attempt to find a binary distribution

### DIFF
--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -265,7 +265,7 @@ export class DafnyInstaller {
       console.error('dafny download failed, trying to build from source', error);
       try {
         // Need to build from source and move all files from Binary/ to the out/resource folder
-        this.writeStatus(`Failed to download binary distribution of Dafny. Installing from source instead.`);
+        this.writeStatus('Failed to download binary distribution of Dafny. Installing from source instead.');
         return await this.installFromSource();
       } catch(error: unknown) {
         this.writeStatus('Dafny build failed:');
@@ -273,7 +273,6 @@ export class DafnyInstaller {
         console.error('failed to build from source', error);
         return false;
       }
-      return false;
     }
   }
 

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -204,7 +204,11 @@ function getDafnyPlatformSuffix(): string {
   case 'Windows_NT':
     return 'win';
   case 'Darwin':
-    return 'osx-10.14.2';
+    if(os.arch() === 'arm64') {
+      return 'osx-11.0';
+    } else {
+      return 'osx-10.14.2';
+    }
   default:
     return 'ubuntu-16.04';
   }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -67,8 +67,6 @@ async function getConfiguredGitTagAndVersionUncached(context: ExtensionContext):
     if(cachedVersion !== undefined) {
       return [ 'nightly', cachedVersion as string ];
     }
-    window.showWarningMessage('Failed to install latest nightly version of Dafny. Using latest stable version instead.\n'
-      + `The name of the nightly release we found was: ${result.name}`);
     version = LanguageServerConstants.LatestVersion;
   }
   }
@@ -334,11 +332,13 @@ export class DafnyInstaller {
       }
     }
 
-    const tag = configuredVersion.startsWith('nightly') ? configuredVersion.split('-').pop() : "v${configuredVersion}";
+    const tag = configuredVersion.startsWith('nightly') ? configuredVersion.split('-').pop() : `v${configuredVersion}`;
 
     // Clone the right version
-    await this.execLog(`git clone -b ${tag} --depth 1 --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);
+    await this.execLog('rm -rf dafny');
+    await this.execLog(`git clone --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);
     processChdir(Utils.joinPath(installationPath, 'dafny').fsPath);
+    await this.execLog(`git checkout ${tag}`);
 
     const { path: dotnet } = await getDotnetExecutablePath();
     // The DafnyCore.csproj has a few targets that call `dotnet` directly.

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -334,8 +334,10 @@ export class DafnyInstaller {
       }
     }
 
+    const tag = configuredVersion.startsWith('nightly') ? configuredVersion.split('-').pop() : "v${configuredVersion}";
+
     // Clone the right version
-    await this.execLog(`git clone -b v${configuredVersion} --depth 1 --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);
+    await this.execLog(`git clone -b ${tag} --depth 1 --recurse-submodules ${LanguageServerConstants.DafnyGitUrl}`);
     processChdir(Utils.joinPath(installationPath, 'dafny').fsPath);
 
     const { path: dotnet } = await getDotnetExecutablePath();

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -264,15 +264,19 @@ export class DafnyInstaller {
     } catch(error: unknown) {
       this.writeStatus('Dafny download failed:');
       this.writeStatus(`> ${error}`);
-      console.error('dafny download failed, trying to build from source', error);
-      try {
-        // Need to build from source and move all files from Binary/ to the out/resource folder
-        this.writeStatus('Failed to download binary distribution of Dafny. Installing from source instead.');
-        return await this.installFromSource();
-      } catch(error: unknown) {
-        this.writeStatus('Dafny build failed:');
-        this.writeStatus(`> ${error}`);
-        console.error('failed to build from source', error);
+      if(os.type() === 'Darwin') {
+        // Building from source works only on macOS at the moment
+        try {
+          // Need to build from source and move all files from Binary/ to the out/resource folder
+          this.writeStatus('Failed to download binary distribution of Dafny. Installing from source instead.');
+          return await this.installFromSource();
+        } catch(error: unknown) {
+          this.writeStatus('Dafny build failed:');
+          this.writeStatus(`> ${error}`);
+          console.error('failed to build from source', error);
+          return false;
+        }
+      } else {
         return false;
       }
     }

--- a/src/language/dafnyInstallation.ts
+++ b/src/language/dafnyInstallation.ts
@@ -216,7 +216,7 @@ async function getDafnyDownloadAddress(context: ExtensionContext): Promise<strin
   const baseUri = LanguageServerConstants.DownloadBaseUri;
   const [ tag, version ] = await getConfiguredTagAndVersion(context);
   const suffix = getDafnyPlatformSuffix();
-  return `${baseUri}/${tag}/dafny-${version}-x64-${suffix}.zip`;
+  return `${baseUri}/${tag}/dafny-${version}-${os.arch()}-${suffix}.zip`;
 }
 
 export class DafnyInstaller {
@@ -254,21 +254,25 @@ export class DafnyInstaller {
     this.writeStatus('Starting Dafny installation');
     try {
       await this.cleanInstallDir();
-      if(os.type() === 'Darwin' && os.arch() !== 'x64') {
-        // Need to build from source and move all files from Binary/ to the out/resource folder
-        this.writeStatus(`Found a non-supported architecture OSX:${os.arch()}. Going to install from source.`);
-        return await this.installFromSource();
-      } else {
-        const archive = await this.downloadArchive(await getDafnyDownloadAddress(this.context), 'Dafny');
-        await this.extractArchive(archive, 'Dafny');
-        await workspace.fs.delete(archive, { useTrash: false });
-        this.writeStatus('Dafny installation completed');
-        return true;
-      }
+      const archive = await this.downloadArchive(await getDafnyDownloadAddress(this.context), 'Dafny');
+      await this.extractArchive(archive, 'Dafny');
+      await workspace.fs.delete(archive, { useTrash: false });
+      this.writeStatus('Dafny installation completed');
+      return true;
     } catch(error: unknown) {
-      this.writeStatus('Dafny installation failed:');
+      this.writeStatus('Dafny download failed:');
       this.writeStatus(`> ${error}`);
-      console.error('dafny installation failed', error);
+      console.error('dafny download failed, trying to build from source', error);
+      try {
+        // Need to build from source and move all files from Binary/ to the out/resource folder
+        this.writeStatus(`Failed to download binary distribution of Dafny. Installing from source instead.`);
+        return await this.installFromSource();
+      } catch(error: unknown) {
+        this.writeStatus('Dafny build failed:');
+        this.writeStatus(`> ${error}`);
+        console.error('failed to build from source', error);
+        return false;
+      }
       return false;
     }
   }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -105,12 +105,12 @@ suite('Dafny IDE Extension Installation', () => {
     ]);
     assert.strictEqual(true, installer != null, 'Installer is not null');
     const result = await installer.install();
-    assert.strictEqual(outputChannelBuilder.writtenContent().replace(/\\/g, '/').replace(/resources\/.*\n/, 'resources/\n'),
-      'Starting Dafny installation\n'
-      + 'deleting previous Dafny installation at /tmp/mockedUri/out/resources/\n'
-      + 'Dafny installation failed:\n'
-      + '> Simulated error in delete\n'
-    );
+    const actual = outputChannelBuilder.writtenContent().replace(/\\/g, '/').replace(/resources\/.*\n/, 'resources/\n');
+    const expectedPrefix = 'Starting Dafny installation\n'
+                         + 'deleting previous Dafny installation at /tmp/mockedUri/out/resources/\n'
+                         + 'Dafny download failed:\n'
+                         + '> Simulated error in delete\n';
+    assert(actual.startsWith(expectedPrefix));
     assert.strictEqual(false, result, 'Result is true');
   }).timeout(60 * 1000);
 });


### PR DESCRIPTION
This updates the installation process to always try to download a binary distribution, using the current OS _and_ architecture, and only build from source if the download fails. This should allow us to support other architectures seamlessly in the future (and support the case where, for some reason, we fail to upload a binary for a certain version/OS/arch combination).