### PR TITLE
Fix github installer paths

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,12 +57,4 @@ export namespace LanguageServerConstants {
   export function GetResourceFolder(version: string): string[] {
     return [ 'out', 'resources', version ];
   }
-
-  export function GetDefaultPath(version: string): string {
-    return `out/resources/${version}/dafny/DafnyLanguageServer.dll`;
-  }
-
-  export function GetDefaultCliPath(version: string): string {
-    return `out/resources/${version}/dafny/Dafny.dll`;
-  }
 }

--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -40,7 +40,7 @@ export class GitHubReleaseInstaller {
     const version = getPreferredVersion();
     const { path: dotnetExecutable } = await getDotnetExecutablePath();
 
-    const cliPath = path.join(this.context.extensionPath, LanguageServerConstants.GetDefaultCliPath(await this.getConfiguredVersion()));
+    const cliPath = path.join((await this.getInstallationPath()).fsPath, 'dafny', 'Dafny.dll');
     if(!fs.existsSync(cliPath)) {
       const installed = await this.install();
       if(!installed) {
@@ -54,7 +54,7 @@ export class GitHubReleaseInstaller {
       }
       return { command: dotnetExecutable, args: [ cliPath, ...newArgs ] };
     } else {
-      const standaloneServerpath = path.join(this.context.extensionPath, LanguageServerConstants.GetDefaultPath(await this.getConfiguredVersion()));
+      const standaloneServerpath = path.join((await (this.getInstallationPath())).fsPath, 'dafny', 'DafnyLanguageServer.dll');
       return { command: dotnetExecutable, args: [ standaloneServerpath, ...oldArgs ] };
     }
   }


### PR DESCRIPTION
Tested twice (to test the installation and the use of an existing installation):
- latest nightly
- latest
- 3.9.1
- custom
- `Ran with $DAFNY_LANGUAGE_SERVER`