### PR TITLE
Introduce a temporary fix for verification cores set to 0

### DIFF
--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -10,6 +10,7 @@ import { IGhostDiagnosticsParams } from './api/ghostDiagnostics';
 import { IVerificationGutterStatusParams as IVerificationGutterStatusParams } from './api/verificationGutterStatusParams';
 import { IVerificationSymbolStatusParams } from './api/verificationSymbolStatusParams';
 import { DafnyInstaller } from './dafnyInstallation';
+import * as os from 'os';
 
 const LanguageServerId = 'dafny-vscode';
 const LanguageServerName = 'Dafny Language Server';
@@ -24,11 +25,14 @@ function getLanguageServerLaunchArgsNew(): string[] {
   const verifyOn: string = map[oldVerifyOnValue];
 
   const launchArgs = Configuration.get<string[]>(ConfigurationConstants.LanguageServer.LaunchArgs);
+  const specifiedCores = parseInt(Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationVirtualCores));
+  // This is a temporary fix to prevent 0 cores from being used, since the languages server currently does not handle 0 cores correctly: https://github.com/dafny-lang/dafny/pull/3276
+  const cores = isNaN(specifiedCores) || specifiedCores === 0 ? (os.cpus().length + 1) / 2 : Math.max(1, specifiedCores);
   return [
     `--verify-on:${verifyOn}`,
     `--verification-time-limit:${Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationTimeLimit)}`,
     getVerifierCachingPolicy(),
-    `--cores:${Configuration.get<string>(ConfigurationConstants.LanguageServer.VerificationVirtualCores)}`,
+    `--cores:${cores}`,
     `--notify-ghostness:${Configuration.get<string>(ConfigurationConstants.LanguageServer.MarkGhostStatements)}`,
     `--notify-line-verification-status:${Configuration.get<string>(ConfigurationConstants.LanguageServer.DisplayGutterStatus)}`,
     ...getDafnyPluginsArgument(),


### PR DESCRIPTION
Introduce a temporary fix so setting verification cores to 0 (the default) doesn't stop verification