### PR TITLE
Reinstated the copy of the executable

### DIFF
--- a/src/test/suite/MockingUtils.ts
+++ b/src/test/suite/MockingUtils.ts
@@ -91,7 +91,8 @@ export class MockingUtils {
         [ ConfigurationConstants.Compiler.CommandPrefix, '<compiler command prefix>' ],
         [ ConfigurationConstants.Dotnet.ExecutablePath, '<dotnet executable path>' ],
         [ ConfigurationConstants.Compiler.Arguments, [ '--output', '<arg1>', 'arg2' ] ],
-        [ ConfigurationConstants.Compiler.OutputDir, '<compiler output dir>' ]
+        [ ConfigurationConstants.Compiler.OutputDir, '<compiler output dir>' ],
+        [ ConfigurationConstants.LanguageServer.CliPath, '<cli path>' ]
       ])
     });
   }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -122,7 +122,7 @@ suite('Dafny IDE Extension Installation', () => {
       assert.fail('installation should fail');
     // eslint-disable-next-line no-empty
     } catch(e: unknown) {
-
+      outputChannelBuilder.outputChannel.append(`${e}`);
     }
     const result = outputChannelBuilder.writtenContent().replace(/\\/g, '/').replace(/resources\/.*\n/, 'resources/\n');
     assert.strictEqual(result,
@@ -130,6 +130,7 @@ suite('Dafny IDE Extension Installation', () => {
       + 'deleting previous Dafny installation at /tmp/mockedUri/out/resources/\n'
       + 'Standalone language server installation failed:\n'
       + '> Simulated error in delete\n'
+      + 'Error: Could not install a Dafny language server.'
     );
   }).timeout(60 * 1000);
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -19,7 +19,8 @@ const mockedVsCode = {
   window: {
     activeTerminal: null as any,
     activeTextEditor: null as any,
-    showInformationMessage: () => {}
+    showInformationMessage: () => {},
+    showWarningMessage: () => {}
   },
   commands: {
     registerCommand(command: string, callback: () => void): vscode.Disposable {


### PR DESCRIPTION
With 3.0.1, the Dlls and executables were no longer copied from a custom installation to the new one. This prevents Dafny developers to compile and then refresh VSCode as it was enabled recently.

This PR fixes that.