### PR TITLE
Fix status view on windows

### DIFF
--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -173,6 +173,7 @@ export default class CompilationStatusView {
     const running = params.namedVerifiables.filter(v => v.status === PublishedVerificationStatus.Running);
     const total = params.namedVerifiables.length;
     let message: string;
+    params.uri = Uri.parse(params.uri).toString();// Makes the Uri canonical
     if(running.length > 0 || queued.length > 0) {
       const document = await workspace.openTextDocument(Uri.parse(params.uri));
       const verifying = running.map(item => document.getText(VerificationSymbolStatusView.convertRange(item.nameRange))).join(', ');


### PR DESCRIPTION
Partially solves the issue #339 

Before when verification finishes on Windows
![image](https://user-images.githubusercontent.com/3601079/210190355-de8995f0-8e72-470a-89c9-a57829e794ae.png)

After this PR when verification finishes on Windows
![image](https://user-images.githubusercontent.com/3601079/210823681-9b5f359b-07ae-43ae-9d3f-a76a78020638.png)
![image](https://user-images.githubusercontent.com/3601079/210824166-9929c48f-9336-4498-8c17-00f2bd56f5b3.png)
![image](https://user-images.githubusercontent.com/3601079/210824231-f8ab0828-18fd-425c-9585-0798a559f810.png)


The reason was that a ":" was converted in a non-canonical way in the language server. This PR canonicalize the URI.
