### PR TITLE
Release v3.0.4 (updated Dafny to 3.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 3.0.4
+- Enable using Dafny 3.11.0
+- Prepare migration to Dafny 4 (https://github.com/dafny-lang/ide-vscode/pull/347)
+
 ## 3.0.3
 - Fix behavior of automatic core selection. (https://github.com/dafny-lang/ide-vscode/pull/336)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ide-vscode",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ide-vscode",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "publisher": "dafny-lang",
   "repository": {
     "type": "git",
@@ -216,6 +216,7 @@
           "type": "string",
           "enum": [
             "latest",
+            "3.11.0",
             "3.10.0",
             "3.9.1",
             "3.9.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,7 +48,7 @@ export namespace LanguageServerConstants {
   export const LatestStable = 'latest';
   export const LatestNightly = 'latest nightly';
   export const Custom = 'custom';
-  export const LatestVersion = '3.10.0';
+  export const LatestVersion = '3.11.0';
   export const UnknownVersion = 'unknown';
   export const DafnyGitUrl = 'https://github.com/dafny-lang/dafny.git';
   export const DownloadBaseUri = 'https://github.com/dafny-lang/dafny/releases/download';

--- a/src/language/dafnyToolInstaller.ts
+++ b/src/language/dafnyToolInstaller.ts
@@ -108,8 +108,7 @@ class DafnyToolInstaller {
       });
       dates.sort((a, b) => a.date < b.date ? 1 : -1);
       const latestNightly = nightlies[dates[0].index];
-      toolVersion = await DafnyInstaller.dafny4upgradeCheck(
-        context, versionDescription, latestNightly);
+      toolVersion = nightlies[dates[0].index];
       window.showInformationMessage(`Using latest nightly version: ${toolVersion}`);
       break;
     }

--- a/src/language/dafnyToolInstaller.ts
+++ b/src/language/dafnyToolInstaller.ts
@@ -107,7 +107,6 @@ class DafnyToolInstaller {
         return { index, date: split[2] + split[3] + split[4] };
       });
       dates.sort((a, b) => a.date < b.date ? 1 : -1);
-      const latestNightly = nightlies[dates[0].index];
       toolVersion = nightlies[dates[0].index];
       window.showInformationMessage(`Using latest nightly version: ${toolVersion}`);
       break;

--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -137,12 +137,8 @@ export class GitHubReleaseInstaller {
         const name: string = result.name;
         const versionPrefix = 'Dafny ';
         if(name.startsWith(versionPrefix)) {
-          let version = name.substring(versionPrefix.length);
+          const version = name.substring(versionPrefix.length);
           this.context.globalState.update('nightly-version', version);
-          version = await DafnyInstaller.dafny4upgradeCheck(
-            this.context,
-            preferredVersion,
-            version);
           return [ 'nightly', version ];
         }
       }
@@ -150,19 +146,11 @@ export class GitHubReleaseInstaller {
       const cachedVersion = this.context.globalState.get('nightly-version');
       if(cachedVersion !== undefined) {
         version = cachedVersion as string;
-        version = await DafnyInstaller.dafny4upgradeCheck(
-          this.context,
-          preferredVersion,
-          version);
         return [ 'nightly', version ];
       }
       window.showWarningMessage('Failed to install latest nightly version of Dafny. Using latest stable version instead.\n'
         + `The name of the nightly release we found was: ${result.name}`);
       version = LanguageServerConstants.LatestVersion;
-      version = await DafnyInstaller.dafny4upgradeCheck(
-        this.context,
-        preferredVersion,
-        version);
     }
     }
     return [ `v${version}`, version ];

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -1,70 +1,8 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { ViewColumn } from 'vscode';
 
 suite('Verification', () => {
-  test('Program with errors has diagnostics', async () => {
-
-    const createChannel: (name: string, languageId: string | undefined) => vscode.OutputChannel = (name, language) => {
-      return {
-        name: name,
-
-        /**
-         * Append the given value to the channel.
-         *
-         * @param value A string, falsy values will not be printed.
-         */
-        append: (value: string) => {},
-
-        /**
-         * Append the given value and a line feed character
-         * to the channel.
-         *
-         * @param value A string, falsy values will be printed.
-         */
-        appendLine: (value: string) => {},
-
-        /**
-         * Replaces all output from the channel with the given value.
-         *
-         * @param value A string, falsy values will not be printed.
-         */
-        replace: (value: string) => {},
-
-        /**
-         * Removes all output from the channel.
-         */
-        clear: () => {},
-
-        /**
-         * Reveal this channel in the UI.
-         *
-         * @param preserveFocus When `true` the channel will not take focus.
-         */
-
-        /**
-         * Reveal this channel in the UI.
-         *
-         * @deprecated Use the overload with just one parameter (`show(preserveFocus?: boolean): void`).
-         *
-         * @param column This argument is **deprecated** and will be ignored.
-         * @param preserveFocus When `true` the channel will not take focus.
-         */
-        show: (column?: ViewColumn, preserveFocus?: boolean) => {},
-
-        /**
-         * Hide this channel from the UI.
-         */
-        hide: () => {},
-
-        /**
-         * Dispose and free associated resources.
-         */
-        dispose: () => {}
-      }
-    };
-    vscode.window.createOutputChannel = createChannel;
-
+  test.only('Program with errors has diagnostics', async () => {
     const extension = vscode.extensions.getExtension('dafny-lang.ide-vscode')!;
     console.log('Waiting for extension activation');
     await extension.activate();

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -5,6 +5,7 @@ suite('Verification', () => {
   test('Program with errors has diagnostics', async () => {
 
     const extension = vscode.extensions.getExtension('dafny-lang.ide-vscode')!;
+    console.log('Waiting for extension activation');
     await extension.activate();
     console.log('Activated extension');
 

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -2,15 +2,12 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('Verification', () => {
-  test.only('Program with errors has diagnostics', async () => {
+  test('Program with errors has diagnostics', async () => {
     const extension = vscode.extensions.getExtension('dafny-lang.ide-vscode')!;
-    console.log('Waiting for extension activation');
     await extension.activate();
-    console.log('Activated extension');
 
     const program = 'method Foo() ensures false {}';
     const document = await vscode.workspace.openTextDocument({ language: 'dafny', content: program });
-    console.log('Opened document');
     await new Promise<void>(resolve => {
       vscode.languages.onDidChangeDiagnostics(() => {
         const diagnostics = vscode.languages.getDiagnostics(document.uri);

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -16,5 +16,5 @@ suite('Verification', () => {
         resolve();
       });
     });
-  }).timeout(10 * 60 * 1000); // We use a large timeout to allow for the Dafny installation to run.
+  }).timeout(3 * 60 * 1000); // We use a large timeout to allow for the Dafny installation to run.
 });

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -1,8 +1,69 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { ViewColumn } from 'vscode';
 
 suite('Verification', () => {
   test('Program with errors has diagnostics', async () => {
+
+    const createChannel: (name: string, languageId: string | undefined) => vscode.OutputChannel = (name, language) => {
+      return {
+        name: name,
+
+        /**
+         * Append the given value to the channel.
+         *
+         * @param value A string, falsy values will not be printed.
+         */
+        append: (value: string) => {},
+
+        /**
+         * Append the given value and a line feed character
+         * to the channel.
+         *
+         * @param value A string, falsy values will be printed.
+         */
+        appendLine: (value: string) => {},
+
+        /**
+         * Replaces all output from the channel with the given value.
+         *
+         * @param value A string, falsy values will not be printed.
+         */
+        replace: (value: string) => {},
+
+        /**
+         * Removes all output from the channel.
+         */
+        clear: () => {},
+
+        /**
+         * Reveal this channel in the UI.
+         *
+         * @param preserveFocus When `true` the channel will not take focus.
+         */
+
+        /**
+         * Reveal this channel in the UI.
+         *
+         * @deprecated Use the overload with just one parameter (`show(preserveFocus?: boolean): void`).
+         *
+         * @param column This argument is **deprecated** and will be ignored.
+         * @param preserveFocus When `true` the channel will not take focus.
+         */
+        show: (column?: ViewColumn, preserveFocus?: boolean) => {},
+
+        /**
+         * Hide this channel from the UI.
+         */
+        hide: () => {},
+
+        /**
+         * Dispose and free associated resources.
+         */
+        dispose: () => {}
+      }
+    };
+    vscode.window.createOutputChannel = createChannel;
 
     const extension = vscode.extensions.getExtension('dafny-lang.ide-vscode')!;
     console.log('Waiting for extension activation');

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -20,5 +20,5 @@ suite('Verification', () => {
         resolve();
       });
     });
-  }).timeout(3 * 60 * 1000); // We use a large timeout to allow for the Dafny installation to run.
+  }).timeout(10 * 60 * 1000); // We use a large timeout to allow for the Dafny installation to run.
 });

--- a/src/test/verification.test.ts
+++ b/src/test/verification.test.ts
@@ -2,13 +2,15 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('Verification', () => {
-  test.only('Program with errors has diagnostics', async () => {
+  test('Program with errors has diagnostics', async () => {
 
     const extension = vscode.extensions.getExtension('dafny-lang.ide-vscode')!;
     await extension.activate();
+    console.log('Activated extension');
 
     const program = 'method Foo() ensures false {}';
     const document = await vscode.workspace.openTextDocument({ language: 'dafny', content: program });
+    console.log('Opened document');
     await new Promise<void>(resolve => {
       vscode.languages.onDidChangeDiagnostics(() => {
         const diagnostics = vscode.languages.getDiagnostics(document.uri);


### PR DESCRIPTION
- Update version to 3.0.4
- Use Dafny 3.11
- Remove the major version upgrade checks when 'latest nightly' is used, since they would always trigger because the 'version' for nightly starts with `n` and that's never equal to the latest major version number.
- Remove `.only` from test, so the other tests run again