### PR TITLE
fix: check commit msg's first line for lastPreparedTag

### DIFF
--- a/publish_process.js
+++ b/publish_process.js
@@ -171,7 +171,7 @@ async function nextVersion(currentVersion) {
 }
 
 async function getLastPreparedTag() {
-  const lastCommitMessage = (await execAsync("git log -1 --pretty=%B")).stdout.trim();
+  const lastCommitMessage = (await execAsync("git log -1 --pretty=%B | head -n 1")).stdout.trim();
   const lastCommitMessageRegex = /(v\d+\.\d+\.\d+)/;
   const match = lastCommitMessageRegex.exec(lastCommitMessage);
   if(match == null) {


### PR DESCRIPTION
This avoids the edge case where a commit message has a semver-style version number in the message body (as is often the case in dependabot commits), which results in the publish process erroneously exiting early.