### PR TITLE
Update the names of release packages

### DIFF
--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -15,18 +15,29 @@ import { DafnyInstaller, getPreferredVersion } from './dafnyInstallation';
 import { configuredVersionToNumeric } from '../ui/dafnyIntegration';
 const ArchiveFileName = 'dafny.zip';
 
-function getDafnyPlatformSuffix(): string {
+function getDafnyPlatformSuffix(version: string): string {
+  const post312 = version.includes('nightly') || configuredVersionToNumeric(version) >= configuredVersionToNumeric('3.13');
   switch(os.type()) {
   case 'Windows_NT':
-    return 'win';
+    if(post312) {
+      return 'windows-2019';
+    } else {
+      return 'win';
+    }
   case 'Darwin':
-    if(os.arch() === 'arm64') {
+    if(post312) {
+      return 'macos-11';
+    } else if(os.arch() === 'arm64') {
       return 'osx-11.0';
     } else {
       return 'osx-10.14.2';
     }
   default:
-    return 'ubuntu-16.04';
+    if(post312) {
+      return 'ubuntu-20.04';
+    } else {
+      return 'ubuntu-16.04';
+    }
   }
 }
 
@@ -100,7 +111,7 @@ export class GitHubReleaseInstaller {
   private async getDafnyDownloadAddress(): Promise<string> {
     const baseUri = LanguageServerConstants.DownloadBaseUri;
     const [ tag, version ] = await this.getConfiguredTagAndVersion();
-    const suffix = getDafnyPlatformSuffix();
+    const suffix = getDafnyPlatformSuffix(version);
     return `${baseUri}/${tag}/dafny-${version}-${os.arch()}-${suffix}.zip`;
   }
 


### PR DESCRIPTION
For 3.13 and later, the names of the binary packages we produce has changed.