### PR TITLE
Support for zero-commit updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dafny for Visual Studio Code 
+# Dafny for Visual Studio Code
 
 This extension adds _Dafny 3_ support to Visual Studio Code. If you require _Dafny 2_ support, consider using the [legacy extension](https://marketplace.visualstudio.com/items?itemName=correctnessLab.dafny-vscode-legacy).
 This VSCode plugin requires the Dafny language server (shipped with the Dafny release since v3.1.0). The plugin will install it automatically upon first use.


### PR DESCRIPTION
- Removed a space in README.md
- `./publish_process.js` now accepts to publish a new version even if there was no added commit to the extension (e.g. to support a new version of Dafny by default)