### PR TITLE
Fix: Function declarations not highlighted as types

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,8 @@
+// Issue #370
+function Map<U(!new)>(): int {
+      // ^^^ should be highlighted like a function name, not a type
+}
+
 // Issue #269
 method SpaceAFterOperator(n: nat)
   requires 1<n

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -147,7 +147,7 @@
 		<key>genericfunctioncalls</key>
 		<dict>
 			<key>begin</key>
-			<string>([a-zA-Z'?][\w'?]*)\s*&lt;(?=[^\)\(]*&gt;(?=\())</string>
+			<string>([a-zA-Z'?][\w'?]*)\s*&lt;(?=(?:[^\)\(]|\((?:!new|,|0|00|==)*\))*&gt;(?=\())</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This highlight adds support for detecting type annotations like `FunName<T(0,!new)>` to ensure it's a function name, not a type
Fixes #370

Proof:
![image](https://user-images.githubusercontent.com/3601079/223209293-214a000d-bb7b-4862-b04a-288be2528687.png)
