### PR TITLE
Support new IDE states, parsing and preparing verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,6 +287,8 @@
       }
     ]
   },
+  "activationEvents": [
+  ],
   "scripts": {
     "vscode:prepublish": "npm run package",
     "compile": "webpack",

--- a/package.json
+++ b/package.json
@@ -287,9 +287,6 @@
       }
     ]
   },
-  "activationEvents": [
-    "onLanguage:dafny"
-  ],
   "scripts": {
     "vscode:prepublish": "npm run package",
     "compile": "webpack",

--- a/src/language/api/compilationStatus.ts
+++ b/src/language/api/compilationStatus.ts
@@ -1,9 +1,11 @@
 import { DocumentUri, integer } from 'vscode-languageclient';
 
 export enum CompilationStatus {
-  ResolutionStarted = 'ResolutionStarted',
+  Parsing = 'Parsing',
   ParsingFailed = 'ParsingFailed',
+  Resolving = 'ResolutionStarted',
   ResolutionFailed = 'ResolutionFailed',
+  PreparingVerification = 'PreparingVerification',
   CompilationSucceeded = 'CompilationSucceeded',
   VerificationStarted = 'VerificationStarted',
   VerificationFailed = 'VerificationFailed',

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -11,14 +11,18 @@ import VerificationSymbolStatusView from './verificationSymbolStatusView';
 
 const StatusBarPriority = 10;
 
-function toStatusMessage(status: CompilationStatus, message?: string | null): string {
+function toStatusMessage(status: CompilationStatus | any, message?: string | null): string {
   switch(status) {
-  case CompilationStatus.ResolutionStarted:
-    return Messages.CompilationStatus.ResolutionStarted;
+  case CompilationStatus.Parsing:
+    return Messages.CompilationStatus.Parsing;
+  case CompilationStatus.Resolving:
+    return Messages.CompilationStatus.Resolving;
   case CompilationStatus.ParsingFailed:
     return Messages.CompilationStatus.ParsingFailed;
   case CompilationStatus.ResolutionFailed:
     return Messages.CompilationStatus.ResolutionFailed;
+  case CompilationStatus.PreparingVerification:
+    return Messages.CompilationStatus.PreparingVerification;
   case CompilationStatus.CompilationSucceeded:
     return Messages.CompilationStatus.CompilationSucceeded;
 
@@ -36,6 +40,7 @@ function toStatusMessage(status: CompilationStatus, message?: string | null): st
       ? `${Messages.CompilationStatus.VerificationFailedOld} ${message}`
       : `${Messages.CompilationStatus.VerificationFailedOld}`;
   }
+  return status.toString();
 }
 
 interface IDocumentStatusMessage {
@@ -113,9 +118,11 @@ export default class CompilationStatusView {
   }
 
   private static readonly handledMessages = new Set([
-    CompilationStatus.ResolutionStarted,
+    CompilationStatus.Parsing,
+    CompilationStatus.Resolving,
     CompilationStatus.ParsingFailed,
     CompilationStatus.ResolutionFailed,
+    CompilationStatus.PreparingVerification,
     CompilationStatus.CompilationSucceeded ]);
 
   public compilationStatusChangedForBefore38(params: ICompilationStatusParams): void {

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -1,8 +1,10 @@
 export namespace Messages {
   export namespace CompilationStatus {
-    export const ResolutionStarted = '$(sync~spin) Resolving...';
+    export const Parsing = '$(sync~spin) Parsing...';
+    export const Resolving = '$(sync~spin) Resolving...';
     export const ParsingFailed = '$(thumbsdown) Parsing Failed';
     export const ResolutionFailed = '$(thumbsdown) Resolution Failed';
+    export const PreparingVerification = '$(sync~spin) Preparing verification...';
     export const CompilationSucceeded = '$(book) Resolved (not verified)';
     export const Verifying = '$(sync~spin) Verifying';
     export const VerificationSucceeded = '$(thumbsup) Verification Succeeded';


### PR DESCRIPTION
### Testing

- New statuses are shown when using Dafny master
- Statuses still work as they did when using Dafny 4.0