### PR TITLE
Fixes "this" highlight

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,8 @@
+// Issue #386
+method Test(thisNat: nat, dothis: nat) {
+          //^^^^            ^^^^ this should not be highlighted separatedly in blue
+}
+
 // Support for opaque keyword
 opaque function Test(): int { 1 }
 //^^^^ should be highlighted as a keyword

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -481,7 +481,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>this</string>
+					<string>\bthis\b</string>
 					<key>name</key>
 					<string>storage.type.dafny</string>
 				</dict>


### PR DESCRIPTION
Before:
![image](https://github.com/dafny-lang/ide-vscode/assets/3601079/5e453ec3-8d26-4aa3-875d-9e72b4d2418c)
Now:
![image](https://github.com/dafny-lang/ide-vscode/assets/3601079/c901ba05-97cb-4333-816e-bc6d989275f5)
