### PR TITLE
Chore: Support labels with primes and question marks

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -7,6 +7,17 @@ function Map<U(!new)>(): int {
       // ^^^ should be highlighted like a function name, not a type
 }
 
+// Issue #380
+method TestMethod()
+  requires b'?: Test() == 1
+{             //^^^^ This should not be highlighted as a type.
+          
+  assert a'?: Test() == 1;
+            //^^^^ This should not be highlighted as a type.
+  label x'?: TestMethod();
+           //^^^^^^^^^^ This should not be highlighted as a type.
+}
+
 // Issue #269
 method SpaceAFterOperator(n: nat)
   requires 1<n

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -133,7 +133,7 @@
 			<key>name</key>
 			<string>meta.type.formaldeclaration</string>
 			<key>begin</key>
-			<string>(?<!\{|:|(?:label|assert|requires)\s*[_\w]+):\s*(?:[\w'?]+\.)*([\w'?]+\b(?!&lt;))</string>
+			<string>(?<!\{|:|(?:label|assert|requires)\s*[_\w'?]+):\s*(?:[\w'?]+\.)*([\w'?]+\b(?!&lt;))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Fixes #380

Before, the syntax highlighter wrongly believe the identifier followed by a colon makes the RHS identifier a type
![image](https://github.com/dafny-lang/ide-vscode/assets/3601079/5ac9b5a3-0a0c-45cf-a34a-4fdbeb65702c)

After, the assert/label/requires correctly takes into account the label as such:
![image](https://github.com/dafny-lang/ide-vscode/assets/3601079/b3012ebe-11df-40a2-9bd8-3b6c9951f4d4)

