### PR TITLE
Fix: Empty ghost diagnostics no longer ignored

### DIFF
--- a/src/ui/ghostDiagnosticsView.ts
+++ b/src/ui/ghostDiagnosticsView.ts
@@ -37,9 +37,6 @@ export default class GhostDiagnosticsView {
     const documentPath = getVsDocumentPath(params);
     this.clearGhostDiagnostics(documentPath);
     const diagnostics = params.diagnostics;
-    if(diagnostics.length === 0) {
-      return;
-    }
     this.diagnosticsByDocument.set(documentPath, diagnostics);
     this.refreshDisplayedGhostDiagnostics(window.activeTextEditor);
   }


### PR DESCRIPTION
For some reason, the IDE was ignoring ghost diagnostics if their length was empty, which can be very frequent after removing ghost code, so ghost highlighting was simply not updated. This PR removes the shortcut so that empty ghost diagnostics erase any current ghost highlighting. Fixes #372