### PR TITLE
Feat: Added the test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
           "group": "7_Dafny@7"
         },
         {
+          "when": "editorTextFocus && editorLangId == dafny",
+          "command": "dafny.test",
+          "group": "7_Dafny@8"
+        },
+        {
           "when": "editorTextFocus && editorLangId == dafny && dafny.counterexampleMenu.CanShowCounterExample",
           "command": "dafny.showCounterexample",
           "group": "7_Dafny@1"
@@ -84,6 +89,12 @@
         "command": "dafny.run",
         "key": "f5",
         "mac": "f5",
+        "when": "editorTextFocus && editorLangId == dafny"
+      },
+      {
+        "command": "dafny.test",
+        "key": "shift+f5",
+        "mac": "⇧f5",
         "when": "editorTextFocus && editorLangId == dafny"
       },
       {
@@ -260,6 +271,10 @@
       {
         "command": "dafny.buildCustomArgs",
         "title": "Dafny: Build with Custom Arguments"
+      },
+      {
+        "command": "dafny.test",
+        "title": "Dafny: Test"
       },
       {
         "command": "dafny.run",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,6 +2,7 @@ export namespace DafnyCommands {
   export const Build = 'dafny.build';
   export const BuildCustomArgs = 'dafny.buildCustomArgs';
   export const Run = 'dafny.run';
+  export const Test = 'dafny.test';
   export const ShowCounterexample = 'dafny.showCounterexample';
   export const HideCounterexample = 'dafny.hideCounterexample';
   export const CopyCounterexamples = 'dafny.copyCounterexamples';


### PR DESCRIPTION
Fixes #417
This PR adds the "Test" command in the contextual Dafny menu.

A bit of context. It's not possible to put several Main methods in included files, but it's definitely possible to put tests in each file as needed. Currently, to run tests, one typically right-clicks "Dafny > build with custom arguments", and then replace everything with "test". There is not even a shortcut for that, although the "test" command is fully supported in Dafny. Moreover, I am adding the "--no-verify" flag by default both on tests and run because 1) it's in the context of a development environment 2) The minimum required for `dafny run` and `dafnyt test` is that the program resolves and the compiler can compile it. 3) Verification of the entire file before testing is at best redundant because it was already verified in the IDE, at worst it forces the user to add a bunch of "assume false" in their code just because they haven't prove some assertions they conjectured.

I think it's fair to say that the usual workflow of testing is complementary to verification, meaning it makes it possible to experiment on specifications before proving them.