### PR TITLE
Prevent verification as tests UI from becoming unresponsive

### DIFF
--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -91,22 +91,25 @@ export default class VerificationSymbolStatusView {
       const runningItems: TestItem[] = [];
       let outerResolve: () => void;
       await this.noRunCreationInProgress;
-      this.noRunCreationInProgress = new Promise((resolve) => {
-        outerResolve = resolve;
-      });
+      try {
+        this.noRunCreationInProgress = new Promise((resolve) => {
+          outerResolve = resolve;
+        });
 
-      const runs = items.map(item => this.languageClient.runVerification({ position: item.range!.start, textDocument: { uri: item.uri!.toString() } }));
-      for(const index in runs) {
-        const success = await runs[index];
-        if(success) {
-          runningItems.push(items[index]);
+        const runs = items.map(item => this.languageClient.runVerification({ position: item.range!.start, textDocument: { uri: item.uri!.toString() } }));
+        for(const index in runs) {
+          const success = await runs[index];
+          if(success) {
+            runningItems.push(items[index]);
+          }
         }
-      }
 
-      if(runningItems.length > 0) {
-        this.createRun(runningItems);
+        if(runningItems.length > 0) {
+          this.createRun(runningItems);
+        }
+      } finally {
+        outerResolve!();
       }
-      outerResolve!();
     }, true);
     return controller;
   }


### PR DESCRIPTION
### Changes

Use a try/finally to ensure the finally code runs. If it doesn't run the whole verification as tests UI gets stuck

### Testing

Manual testing for now.