### PR TITLE
Client side gutter icons

### DIFF
--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -34,7 +34,7 @@ function getLanguageServerLaunchArgsNew(): string[] {
     getVerifierCachingPolicy(),
     `--cores:${cores}`,
     `--notify-ghostness:${Configuration.get<string>(ConfigurationConstants.LanguageServer.MarkGhostStatements)}`,
-    `--notify-line-verification-status:${Configuration.get<string>(ConfigurationConstants.LanguageServer.DisplayGutterStatus)}`,
+    '--notify-line-verification-status:false',
     ...getDafnyPluginsArgument(),
     ...launchArgs
   ];

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -10,6 +10,7 @@ import VerificationSymbolStatusView from './verificationSymbolStatusView';
 import Configuration from '../configuration';
 import { ConfigurationConstants, LanguageServerConstants } from '../constants';
 import { DafnyInstaller } from '../language/dafnyInstallation';
+import GutterIconsView from './gutterIconsView';
 
 export default function createAndRegisterDafnyIntegration(
   installer: DafnyInstaller,
@@ -21,8 +22,10 @@ export default function createAndRegisterDafnyIntegration(
   const compilationStatusView = CompilationStatusView.createAndRegister(installer.context, languageClient, languageServerVersion);
   let symbolStatusView: VerificationSymbolStatusView | undefined = undefined;
   const serverSupportsSymbolStatusView = configuredVersionToNumeric('3.8.0') <= configuredVersionToNumeric(languageServerVersion);
+  const gutterViewUi = VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient, compilationStatusView);
+    new GutterIconsView(languageClient, gutterViewUi, symbolStatusView);
   } else {
     if(serverSupportsSymbolStatusView) {
       compilationStatusView.registerAfter38Messages();
@@ -30,7 +33,6 @@ export default function createAndRegisterDafnyIntegration(
       compilationStatusView.registerBefore38Messages();
     }
   }
-  VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   CompileCommands.createAndRegister(installer);
   RelatedErrorView.createAndRegister(installer.context, languageClient);
   DafnyVersionView.createAndRegister(installer, languageServerVersion);

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -25,7 +25,8 @@ export default function createAndRegisterDafnyIntegration(
   const gutterViewUi = VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient, compilationStatusView);
-    if(Configuration.get<string>(ConfigurationConstants.LanguageServer.DisplayGutterStatus) === 'true') {
+    const displayGutterStatus = Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayGutterStatus);
+    if(displayGutterStatus) {
       new GutterIconsView(languageClient, gutterViewUi, symbolStatusView);
     }
   } else {

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -25,7 +25,9 @@ export default function createAndRegisterDafnyIntegration(
   const gutterViewUi = VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient, compilationStatusView);
-    new GutterIconsView(languageClient, gutterViewUi, symbolStatusView);
+    if(Configuration.get<string>(ConfigurationConstants.LanguageServer.DisplayGutterStatus) === 'true') {
+      new GutterIconsView(languageClient, gutterViewUi, symbolStatusView);
+    }
   } else {
     if(serverSupportsSymbolStatusView) {
       compilationStatusView.registerAfter38Messages();

--- a/src/ui/gutterIconsView.ts
+++ b/src/ui/gutterIconsView.ts
@@ -1,0 +1,129 @@
+/* eslint-disable max-depth */
+/* eslint-disable @typescript-eslint/brace-style */
+import { Diagnostic, DocumentSymbol, ExtensionContext, Range, Uri, window, workspace } from 'vscode';
+import { DafnyLanguageClient } from '../language/dafnyLanguageClient';
+import CompilationStatusView from './compilationStatusView';
+import { IVerificationGutterStatusParams, LineVerificationStatus } from '../language/api/verificationGutterStatusParams';
+import { NamedVerifiableStatus, PublishedVerificationStatus } from '../language/api/verificationSymbolStatusParams';
+import VerificationSymbolStatusView from './verificationSymbolStatusView';
+
+/**
+ * This class shows verification tasks through the VSCode testing UI.
+ */
+export default class GutterIconsView {
+
+
+  public constructor(
+    private readonly context: ExtensionContext,
+    private readonly languageClient: DafnyLanguageClient,
+    private readonly compilationStatusView: CompilationStatusView)
+  {
+    languageClient.onPublishDiagnostics((uri, diagnostics) => {
+
+    });
+  }
+
+  private nameToSymbolRange(rootSymbols: DocumentSymbol[]): Map<Range, Range> {
+
+  }
+
+  /*
+  No support for first-time icons yet. For first time we pretend like the symbol was previously verified.
+  Error context is only triggered if the symbol currently has an error, not if it only had an error and is currently verifying.
+  */
+  private async computeNewGutterIcons(uri: Uri, nameToSymbolRanges: Map<Range, Range>,
+    statuses: NamedVerifiableStatus[],
+    diagnostics: Diagnostic[]): Promise<IVerificationGutterStatusParams>
+  {
+    const document = await workspace.openTextDocument(uri);
+    const statusPerLine = new Map<number, PublishedVerificationStatus>();
+    const linesWithErrors = new Map<number, boolean>();
+    const lineToSymbolRange = new Map<number, Range>();
+    const linesInErrorContext = new Set<number>();
+
+    for(const range of nameToSymbolRanges.values()) {
+      for(let line = range.start.line; line < range.end.line; line++) {
+        lineToSymbolRange.set(line, range);
+      }
+    }
+    const perLineStatus: LineVerificationStatus[] = [];
+    for(const diagnostic of diagnostics) {
+      for(let line = diagnostic.range.start.line; line < diagnostic.range.end.line; line++) {
+        linesWithErrors.set(line, diagnostic.source === 'Parser');
+        const contextRange = lineToSymbolRange.get(line)!;
+        for(let line = contextRange.start.line; line < contextRange.end.line; line++) {
+          linesInErrorContext.add(line);
+        }
+      }
+    }
+
+    for(const status of statuses) {
+      const symbolRange = nameToSymbolRanges.get(VerificationSymbolStatusView.convertRange(status.nameRange))!;
+      for(let line = symbolRange.start.line; line < symbolRange.end.line; line++) {
+        statusPerLine.set(line, status.status);
+      }
+    }
+    for(let line = 0; line < document.lineCount; line++) {
+      const error = linesWithErrors.get(line);
+      if(error === true) {
+        perLineStatus.push(LineVerificationStatus.ResolutionError);
+      } else {
+        let bigNumber: number;
+        if(error === false) {
+          bigNumber = LineVerificationStatus.AssertionFailed;
+        } else {
+          if(linesInErrorContext.has(line)) {
+            bigNumber = LineVerificationStatus.ErrorContext;
+          } else {
+            bigNumber = LineVerificationStatus.Verified;
+          }
+        }
+        let smallNumber: number;
+        switch(statusPerLine.get(line)) {
+        case PublishedVerificationStatus.Stale:
+        case PublishedVerificationStatus.Queued:
+          smallNumber = 0;
+          break;
+        case PublishedVerificationStatus.Running:
+          smallNumber = 1;
+          break;
+        case PublishedVerificationStatus.Error:
+        case PublishedVerificationStatus.Correct:
+          smallNumber = 2;
+          break;
+        default: throw new Error(`unknown PublishedVerificationStatus ${statusPerLine.get(line)}`);
+        }
+        perLineStatus.push(bigNumber + smallNumber);
+      }
+    }
+    return { uri: uri.toString(), perLineStatus: perLineStatus };
+  }
+
+//   export enum LineVerificationStatus {
+//     // Default value for every line, before the renderer figures it out.
+//     Nothing = 0,
+//     // For first-time computation not actively computing but soon. Synonym of "obsolete"
+//     // (scheduledComputation)
+//     Scheduled = 1,
+//     // For first-time computations, actively computing
+//     Verifying = 2,
+//     // Also applicable for empty spaces if they are not surrounded by errors.
+//     Verified = 200,
+//     VerifiedObsolete = 201,
+//     VerifiedVerifying = 202,
+//    // For trees containing children with errors (e.g. methods)
+//     ErrorContext = 300,
+//     ErrorContextObsolete = 301,
+//     ErrorContextVerifying = 302,
+//     // For individual assertions in error ranges
+//     AssertionVerifiedInErrorContext = 350,
+//     AssertionVerifiedInErrorContextObsolete = 351,
+//     AssertionVerifiedInErrorContextVerifying = 352,
+//     // For specific lines which have errors on it. They take over verified assertions
+//     AssertionFailed = 400,
+//     AssertionFailedObsolete = 401,
+//     AssertionFailedVerifying = 402,
+//     // For lines containing resolution or parse errors
+//     ResolutionError = 500,
+//   }
+}

--- a/src/ui/gutterIconsView.ts
+++ b/src/ui/gutterIconsView.ts
@@ -118,33 +118,33 @@ export default class GutterIconsView {
       if(error === 'Parser' || error === 'Resolver') {
         perLineStatus.push(LineVerificationStatus.ResolutionError);
       } else {
-        let bigNumber: number;
+        let resultStatus: number;
         if(error !== undefined) {
-          bigNumber = LineVerificationStatus.AssertionFailed;
+          resultStatus = LineVerificationStatus.AssertionFailed;
         } else {
           if(linesInErrorContext.has(line)) {
-            bigNumber = LineVerificationStatus.ErrorContext;
+            resultStatus = LineVerificationStatus.ErrorContext;
           } else {
-            bigNumber = LineVerificationStatus.Verified;
+            resultStatus = LineVerificationStatus.Verified;
           }
         }
-        let smallNumber: number;
+        let progressStatus: number;
         switch(statusPerLine.get(line)) {
         case PublishedVerificationStatus.Stale:
         case PublishedVerificationStatus.Queued:
-          smallNumber = GutterIconProgress.Stale;
+          progressStatus = GutterIconProgress.Stale;
           break;
         case PublishedVerificationStatus.Running:
-          smallNumber = GutterIconProgress.Running;
+          progressStatus = GutterIconProgress.Running;
           break;
         case PublishedVerificationStatus.Error:
         case PublishedVerificationStatus.Correct:
         case undefined:
-          smallNumber = GutterIconProgress.Done;
+          progressStatus = GutterIconProgress.Done;
           break;
         default: throw new Error(`unknown PublishedVerificationStatus ${statusPerLine.get(line)}`);
         }
-        perLineStatus.push(bigNumber + smallNumber);
+        perLineStatus.push(resultStatus + progressStatus);
       }
     }
     return { uri: uri.toString(), perLineStatus: perLineStatus };

--- a/src/ui/gutterIconsView.ts
+++ b/src/ui/gutterIconsView.ts
@@ -6,22 +6,21 @@ import { IVerificationGutterStatusParams, LineVerificationStatus } from '../lang
 import { NamedVerifiableStatus, PublishedVerificationStatus } from '../language/api/verificationSymbolStatusParams';
 import VerificationSymbolStatusView from './verificationSymbolStatusView';
 import VerificationGutterStatusView from './verificationGutterStatusView';
+import SymbolStatusService from './symbolStatusService';
 
-/**
- * This class shows verification tasks through the VSCode testing UI.
- */
+// TODO merge with VerificationGutterStatusView
 export default class GutterIconsView {
 
   public constructor(
     private readonly languageClient: DafnyLanguageClient,
     private readonly gutterViewUi: VerificationGutterStatusView,
-    private readonly symbolStatusView: VerificationSymbolStatusView)
+    private readonly symbolStatusService: SymbolStatusService)
   {
     languageClient.onPublishDiagnostics((uri) => {
       this.update(uri);
     });
-    symbolStatusView.onUpdates(uri => {
-      this.update(uri);
+    symbolStatusService.onUpdates(params => {
+      this.update(Uri.parse(params.uri));
     });
   }
 
@@ -32,7 +31,7 @@ export default class GutterIconsView {
     }
     const nameToSymbolRange = this.getNameToSymbolRange(rootSymbols);
     const diagnostics = languages.getDiagnostics(uri);
-    const symbolStatus = this.symbolStatusView.getUpdatesForFile(uri.toString());
+    const symbolStatus = this.symbolStatusService.getUpdatesForFile(uri.toString());
 
     const icons = await this.computeNewGutterIcons(uri, nameToSymbolRange, symbolStatus?.namedVerifiables, diagnostics);
     this.gutterViewUi.updateVerificationStatusGutter(icons, false);

--- a/src/ui/symbolStatusService.ts
+++ b/src/ui/symbolStatusService.ts
@@ -1,0 +1,29 @@
+import { ExtensionContext, Event, EventEmitter } from 'vscode';
+import { DafnyLanguageClient } from '../language/dafnyLanguageClient';
+import { IVerificationSymbolStatusParams } from '../language/api/verificationSymbolStatusParams';
+
+
+/**
+ * This class shows verification tasks through the VSCode testing UI.
+ */
+export default class SymbolStatusService {
+  private readonly updatesPerFile: Map<string, IVerificationSymbolStatusParams> = new Map();
+  private readonly _onUpdates: EventEmitter<IVerificationSymbolStatusParams> = new EventEmitter();
+  public onUpdates: Event<IVerificationSymbolStatusParams> = this._onUpdates.event;
+
+  public constructor(
+    context: ExtensionContext,
+    languageClient: DafnyLanguageClient) {
+
+    context.subscriptions.push(
+      languageClient.onVerificationSymbolStatus(params => {
+        this.updatesPerFile.set(params.uri, params);
+        this._onUpdates.fire(params);
+      })
+    );
+  }
+
+  public getUpdatesForFile(uri: string): IVerificationSymbolStatusParams | undefined {
+    return this.updatesPerFile.get(uri);
+  }
+}

--- a/src/ui/verificationGutterStatusView.ts
+++ b/src/ui/verificationGutterStatusView.ts
@@ -308,7 +308,7 @@ export default class VerificationGutterStatusView {
   }
 
   // Entry point when receiving IVErificationStatusGutter
-  private async updateVerificationStatusGutter(params: IVerificationGutterStatusParams): Promise<void> {
+  public async updateVerificationStatusGutter(params: IVerificationGutterStatusParams): Promise<void> {
     if(this.areParamsOutdated(params)) {
       return;
     }

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -99,22 +99,25 @@ export default class VerificationSymbolStatusView {
       const runningItems: TestItem[] = [];
       let outerResolve: () => void;
       await this.noRunCreationInProgress;
-      this.noRunCreationInProgress = new Promise((resolve) => {
-        outerResolve = resolve;
-      });
+      try {
+        this.noRunCreationInProgress = new Promise((resolve) => {
+          outerResolve = resolve;
+        });
 
-      const runs = items.map(item => this.languageClient.runVerification({ position: item.range!.start, textDocument: { uri: item.uri!.toString() } }));
-      for(const index in runs) {
-        const success = await runs[index];
-        if(success) {
-          runningItems.push(items[index]);
+        const runs = items.map(item => this.languageClient.runVerification({ position: item.range!.start, textDocument: { uri: item.uri!.toString() } }));
+        for(const index in runs) {
+          const success = await runs[index];
+          if(success) {
+            runningItems.push(items[index]);
+          }
         }
-      }
 
-      if(runningItems.length > 0) {
-        this.createRun(runningItems);
+        if(runningItems.length > 0) {
+          this.createRun(runningItems);
+        }
+      } finally {
+        outerResolve!();
       }
-      outerResolve!();
     }, true);
     return controller;
   }


### PR DESCRIPTION
### Changes
- Compute gutter icons on the client and configure the server so it no longer sends gutter icons to the client.

### Testing
- Manual testing looked good, but @MikaelMayer I don't know the icons well enough to know if it behaved the same. I think there might be differences in behavior when there is a resolution error, although the 'new' behavior seems fine to me.
- TODO I will add unit tests for the method `computeNewGutterIcons`, to check that given the particular symbolStatus, diagnostics and documentSymbol information, the right gutter icons are computed.
- I will not add an integration test that runs an actual language server and checks that the icons per line evolve according to expectations. Such a test would be difficult to make stable because it depends on having a running language server.