### PR TITLE
Always show all verifiable symbols in the test panels

### DIFF
--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -188,7 +188,7 @@ export default class CompilationStatusView {
       if(running.length > 0) {
         message += `, verifying ${verifying}`;
       } else {
-        message += ', waiting for free solvers';
+        message += ', preparing verification';
       }
     } else {
       const skipped = params.namedVerifiables.filter(v => v.status === PublishedVerificationStatus.Stale).length;

--- a/src/ui/verificationGutterStatusView.ts
+++ b/src/ui/verificationGutterStatusView.ts
@@ -258,12 +258,13 @@ export default class VerificationGutterStatusView {
 
   // Converts the IVerificationStatusGutter to a map from line verification status
   // to an array of ranges that VSCode can consume.
-  private async getRangesOfLineStatus(params: IVerificationGutterStatusParams): Promise<Map<LineVerificationStatus, Range[]>> {
+  private getRangesOfLineStatus(params: IVerificationGutterStatusParams): Map<LineVerificationStatus, Range[]> {
     const perLineStatus = this.addCosmetics(params.perLineStatus);
 
+    const uri = Uri.parse(params.uri);
     const symbolParams
       = params.perLineStatus.indexOf(LineVerificationStatus.ResolutionError) > 0 ? []
-        : await (this.symbolStatusView?.getVerifiableRanges(params.uri) ?? Promise.resolve([]));
+        : (this.symbolStatusView?.getVerifiableRangesForUri(uri) ?? []);
     const originalLinesToSkip = symbolParams.map(range => range.start.line).sort((a, b) => a - b);
 
     return VerificationGutterStatusView.perLineStatusToRanges(perLineStatus, originalLinesToSkip);
@@ -308,13 +309,13 @@ export default class VerificationGutterStatusView {
   }
 
   // Entry point when receiving IVErificationStatusGutter
-  private async updateVerificationStatusGutter(params: IVerificationGutterStatusParams): Promise<void> {
+  private updateVerificationStatusGutter(params: IVerificationGutterStatusParams) {
     if(this.areParamsOutdated(params)) {
       return;
     }
     params.uri = Uri.parse(params.uri).toString();// Makes the Uri canonical
     const documentPath = getVsDocumentPath(params);
-    const ranges = await this.getRangesOfLineStatus(params);
+    const ranges = this.getRangesOfLineStatus(params);
 
     const newData: LinearVerificationGutterStatus = {
       decorations: ranges,


### PR DESCRIPTION
### Changes
- Show "preparing verification" instead of "waiting for free solver" when all verification symbols are in a queued state. This is OK for Dafny 4.2.0, since "preparing verification" could mean "waiting for free solver". For the upcoming Dafny, this situation usually happens when Dafny is performing translation to Boogie and resolution to Boogie, so the message "preparing verification" is more correct.
- Always show all known verification symbols in the test panel, instead of only those included in the current file. Together with project mode, this enables easily getting an overview of all verifiables available in the project.

### Testing
- Opened a customer project. Triggered verification for everything in the project. Inspected the status bar, gutter icons and the testing panel.