### PR TITLE
Make status bar forward compatible with upcoming Dafny release

### DIFF
--- a/src/language/api/compilationStatus.ts
+++ b/src/language/api/compilationStatus.ts
@@ -6,6 +6,7 @@ export enum CompilationStatus {
   Resolving = 'ResolutionStarted',
   ResolutionFailed = 'ResolutionFailed',
   PreparingVerification = 'PreparingVerification',
+  ResolutionSucceeded = 'ResolutionSucceeded',
   CompilationSucceeded = 'CompilationSucceeded',
   VerificationStarted = 'VerificationStarted',
   VerificationFailed = 'VerificationFailed',

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -1,4 +1,4 @@
-import { Disposable, Uri, Diagnostic } from 'vscode';
+import { Disposable, Uri, Diagnostic, EventEmitter, Event } from 'vscode';
 import { HandleDiagnosticsSignature, LanguageClient, LanguageClientOptions, ServerOptions, TextDocumentPositionParams } from 'vscode-languageclient/node';
 
 import Configuration from '../configuration';
@@ -127,6 +127,9 @@ export class DafnyLanguageClient extends LanguageClient {
     private readonly diagnosticsListeners: DiagnosticListener[], forceDebug?: boolean) {
     super(id, name, serverOptions, clientOptions, forceDebug);
     this.diagnosticsListeners = diagnosticsListeners;
+    this.onReady().then(() => {
+      this.onNotification('dafny/textDocument/symbolStatus', params => this._onVerificationSymbolStatus.fire(params));
+    });
   }
 
   public getCounterexamples(param: ICounterexampleParams): Promise<ICounterexampleItem[]> {
@@ -173,9 +176,9 @@ export class DafnyLanguageClient extends LanguageClient {
     return this.onNotification('dafny/verification/status/gutter', callback);
   }
 
-  public onVerificationSymbolStatus(callback: (params: IVerificationSymbolStatusParams) => void): Disposable {
-    return this.onNotification('dafny/textDocument/symbolStatus', callback);
-  }
+  private readonly _onVerificationSymbolStatus: EventEmitter<IVerificationSymbolStatusParams> = new EventEmitter();
+
+  public OnVerificationSymbolStatus: Event<IVerificationSymbolStatusParams> = this._onVerificationSymbolStatus.event;
 
   public onCompilationStatus(callback: (params: ICompilationStatusParams) => void): Disposable {
     return this.onNotification('dafny/compilation/status', callback);

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -216,17 +216,21 @@ export default class CompilationStatusView {
       }
     } else {
       const skipped = statuses.filter(v => v.status === PublishedVerificationStatus.Stale).length;
-      const errors = statuses.filter(v => v.status === PublishedVerificationStatus.Error).length;
-      const succeeded = completed - errors;
+      const errors = statuses.filter(v => v.status === PublishedVerificationStatus.Error);
+      const errorCount = errors.length;
+      const succeeded = completed - errorCount;
 
-      if(errors === 0) {
+      if(errorCount === 0) {
         if(skipped === 0) {
           message = Messages.CompilationStatus.VerificationSucceeded;
         } else {
           message = `Verified ${succeeded} declarations, skipped ${skipped}`;
         }
       } else {
-        message = `${Messages.CompilationStatus.VerificationFailed} ${(errors > 1 ? `${errors} declarations` : 'a declaration')}`;
+        const object = errorCount > 1
+          ? `${errorCount} declarations`
+          : (document.getText(VerificationSymbolStatusView.convertRange(errors[0].nameRange)) ?? 'a declaration');
+        message = `${Messages.CompilationStatus.VerificationFailed} ${object}`;
       }
     }
     this.verifiableRangeMessages.set(uri.toString(), message);

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -75,11 +75,10 @@ export default class CompilationStatusView {
     );
 
     if(useOnVerificationSymbolStatus) {
-      languageClient.onVerificationSymbolStatus(params => {
-        view.showVerifiableRangesInStatusBar(params);
-      });
-
       context.subscriptions.push(
+        languageClient.OnVerificationSymbolStatus(params => {
+          view.showVerifiableRangesInStatusBar(params);
+        }),
         languageClient.onCompilationStatus(params => view.compilationStatusChangedAfter38(params))
       );
     } else {

--- a/src/ui/compilationStatusView.ts
+++ b/src/ui/compilationStatusView.ts
@@ -141,6 +141,7 @@ export default class CompilationStatusView {
     if(params.status === CompilationStatus.ResolutionSucceeded) {
       const verifiableRangeMessage = this.verifiableRangeMessages.get(params.uri);
       if(verifiableRangeMessage === undefined) {
+        // If we have not yet received verification symbols, then pretend we're still resolving.
         this.compilationStatusChangedAfter38({ ...params, status: CompilationStatus.Resolving });
       } else {
         this.setDocumentStatusMessage(

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -18,18 +18,12 @@ export default function createAndRegisterDafnyIntegration(
 ): void {
   CounterexamplesView.createAndRegister(installer.context, languageClient);
   GhostDiagnosticsView.createAndRegister(installer.context, languageClient);
-  const compilationStatusView = CompilationStatusView.createAndRegister(installer.context, languageClient, languageServerVersion);
   let symbolStatusView: VerificationSymbolStatusView | undefined = undefined;
   const serverSupportsSymbolStatusView = configuredVersionToNumeric('3.8.0') <= configuredVersionToNumeric(languageServerVersion);
   if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
-    symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient, compilationStatusView);
-  } else {
-    if(serverSupportsSymbolStatusView) {
-      compilationStatusView.registerAfter38Messages();
-    } else {
-      compilationStatusView.registerBefore38Messages();
-    }
+    symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient);
   }
+  CompilationStatusView.createAndRegister(installer.context, languageClient, symbolStatusView, languageServerVersion);
   VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   CompileCommands.createAndRegister(installer);
   RelatedErrorView.createAndRegister(installer.context, languageClient);

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -23,7 +23,7 @@ export default function createAndRegisterDafnyIntegration(
   if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient);
   }
-  CompilationStatusView.createAndRegister(installer.context, languageClient, symbolStatusView, languageServerVersion);
+  CompilationStatusView.createAndRegister(installer.context, languageClient, serverSupportsSymbolStatusView, languageServerVersion);
   VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   CompileCommands.createAndRegister(installer);
   RelatedErrorView.createAndRegister(installer.context, languageClient);

--- a/src/ui/dafnyIntegration.ts
+++ b/src/ui/dafnyIntegration.ts
@@ -18,12 +18,12 @@ export default function createAndRegisterDafnyIntegration(
 ): void {
   CounterexamplesView.createAndRegister(installer.context, languageClient);
   GhostDiagnosticsView.createAndRegister(installer.context, languageClient);
-  let symbolStatusView: VerificationSymbolStatusView | undefined = undefined;
   const serverSupportsSymbolStatusView = configuredVersionToNumeric('3.8.0') <= configuredVersionToNumeric(languageServerVersion);
+  CompilationStatusView.createAndRegister(installer.context, languageClient, serverSupportsSymbolStatusView, languageServerVersion);
+  let symbolStatusView: VerificationSymbolStatusView | undefined = undefined;
   if(serverSupportsSymbolStatusView && Configuration.get<boolean>(ConfigurationConstants.LanguageServer.DisplayVerificationAsTests)) {
     symbolStatusView = VerificationSymbolStatusView.createAndRegister(installer.context, languageClient);
   }
-  CompilationStatusView.createAndRegister(installer.context, languageClient, serverSupportsSymbolStatusView, languageServerVersion);
   VerificationGutterStatusView.createAndRegister(installer.context, languageClient, symbolStatusView);
   CompileCommands.createAndRegister(installer);
   RelatedErrorView.createAndRegister(installer.context, languageClient);

--- a/src/ui/verificationGutterStatusView.ts
+++ b/src/ui/verificationGutterStatusView.ts
@@ -265,7 +265,7 @@ export default class VerificationGutterStatusView {
     const symbolParams
       = params.perLineStatus.indexOf(LineVerificationStatus.ResolutionError) > 0 ? []
         : (this.symbolStatusView?.getVerifiableRangesForUri(uri) ?? []);
-    const originalLinesToSkip = symbolParams.map(range => range.nameRange.start.line).sort((a, b) => a - b);
+    const originalLinesToSkip = symbolParams.map(range => range.start.line).sort((a, b) => a - b);
 
     return VerificationGutterStatusView.perLineStatusToRanges(perLineStatus, originalLinesToSkip);
   }

--- a/src/ui/verificationGutterStatusView.ts
+++ b/src/ui/verificationGutterStatusView.ts
@@ -265,7 +265,7 @@ export default class VerificationGutterStatusView {
     const symbolParams
       = params.perLineStatus.indexOf(LineVerificationStatus.ResolutionError) > 0 ? []
         : (this.symbolStatusView?.getVerifiableRangesForUri(uri) ?? []);
-    const originalLinesToSkip = symbolParams.map(range => range.start.line).sort((a, b) => a - b);
+    const originalLinesToSkip = symbolParams.map(range => range.nameRange.start.line).sort((a, b) => a - b);
 
     return VerificationGutterStatusView.perLineStatusToRanges(perLineStatus, originalLinesToSkip);
   }

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -46,7 +46,7 @@ export default class VerificationSymbolStatusView {
     context.subscriptions.push(this.controller);
 
     context.subscriptions.push(
-      languageClient.onVerificationSymbolStatus(params => this.update(params))
+      languageClient.OnVerificationSymbolStatus(params => this.update(params))
     );
   }
 

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -28,12 +28,6 @@ interface ItemRunState {
   startedRunningTime?: number;
 }
 
-export function createAndRegister(
-  context: ExtensionContext,
-  languageClient: DafnyLanguageClient): VerificationSymbolStatusView {
-  return new VerificationSymbolStatusView(context, languageClient);
-}
-
 /**
  * This class shows verification tasks through the VSCode testing UI.
  */

--- a/src/ui/verificationSymbolStatusView.ts
+++ b/src/ui/verificationSymbolStatusView.ts
@@ -161,7 +161,6 @@ export default class VerificationSymbolStatusView {
     document: TextDocument,
     rootSymbols: DocumentSymbol[] | undefined) {
 
-    this.compilationStatusView.updateStatusBar(params);
     const controller = this.controller;
 
     this.clearItemsForUri(document.uri);
@@ -178,6 +177,8 @@ export default class VerificationSymbolStatusView {
         controller.items.add(leafItem);
       }
     }
+
+    this._onUpdates.fire(document.uri);
 
     const allTestItems: TestItem[] = [];
     function collectTestItems(collection: TestItemCollection) {


### PR DESCRIPTION
### Changes
- Let the status bar remember the message it has when resolution was previously finished, so it can show that message again when resolution finishes again. This is required to keep an up-to-date status bar together with the server changes in https://github.com/dafny-lang/dafny/pull/4523. This change is only triggered by the new event "ResolutionSucceeded", and so is backwards compatible with older Dafny versions.
- Do not let `VerificationSymbolStatusView` update the status bar, but let the status bar work independently, so the status bar remains up to date even if 'verification as tests' is turned off.

### Testing
- Test that the status bar behaves well with https://github.com/dafny-lang/dafny/pull/4523 
- Test that the status bar behaves well on Dafny 4.2
- Did not manage to test against 3.7 because of my M1 laptop and failing to build it locally. Any chance you could do that @MikaelMayer ?