### PR TITLE
fix: relax .NET runtime version check

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,7 +41,8 @@ export namespace ConfigurationConstants {
 
 export namespace DotnetConstants {
   export const ExecutableName = 'dotnet';
-  export const SupportedRuntimesPattern = /Microsoft\.AspNetCore\.App\s*[56]\.0/i;
+  export const SupportedRuntimesPattern = /Microsoft\.NETCore\.App\s*((\d+)\.\d+\.\d+)/ig;
+  export const SupportedRuntimesMinVersion = 5;
 }
 
 export namespace LanguageServerConstants {

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -20,18 +20,18 @@ export async function checkSupportedDotnetVersion(): Promise<string | undefined>
       return dotnetExecutable + Messages.Dotnet.IsNotAnExecutableFile;
     }
     const { stdout } = await execFileAsync(dotnetExecutable, [ ListRuntimesArg ]);
-    const runtimeVersions = [...stdout.matchAll(DotnetConstants.SupportedRuntimesPattern)]
+    const runtimeVersions = [ ...stdout.matchAll(DotnetConstants.SupportedRuntimesPattern) ]
       .map(match => {
-        const version = match[1];
+        const full = match[1];
         const major = parseInt(match[2], 10);
-        return [major, version] as [number, string];
+        return { full, major };
       });
-    if (runtimeVersions.find(([major, _]) => major >= DotnetConstants.SupportedRuntimesMinVersion) !== undefined) {
+    if(runtimeVersions.find(({ major }) => major >= DotnetConstants.SupportedRuntimesMinVersion) !== undefined) {
       return undefined;
     }
     const runtimeVersionsStr = runtimeVersions.length === 0
-      ? " no installed versions"
-      : runtimeVersions.map(([_, version]) => version).join(", ");
+      ? ' no installed versions'
+      : runtimeVersions.map(({ full }) => full).join(', ');
     return dotnetExecutable + Messages.Dotnet.NotASupportedDotnetInstallation + runtimeVersionsStr;
   } catch(error: unknown) {
     const errorMsg = `Error invoking ${dotnetExecutable} ${ListRuntimesArg}: ${error}`;

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -29,9 +29,9 @@ export namespace Messages {
 
   export namespace Dotnet {
     export const IsNotAnExecutableFile = ' is not an executable dotnet file.';
-    export const NotASupportedDotnetInstallation = ' is not a compatible dotnet file. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0, got ';
-    export const FailedDotnetExecution = 'Failed to execute dotnet. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
-    export const NoCompatibleInstallation = 'No compatible dotnet runtime found. Dafny requires the ASP.NET Core Runtime 5.0 or 6.0.';
+    export const NotASupportedDotnetInstallation = ' is not a compatible dotnet file. Dafny requires the .NET Runtime 5.0 or greater, found ';
+    export const FailedDotnetExecution = 'Failed to execute dotnet. Dafny requires the .NET Runtime 5.0 or greater.';
+    export const NoCompatibleInstallation = 'No compatible dotnet runtime found. Dafny requires the .NET Runtime 5.0 or greater.';
     export const ChangeConfiguration = 'Configure the absolute path to dotnet';
     export const VisitDownload = 'Get .NET SDK';
     export const DownloadUri = 'https://dotnet.microsoft.com/download/dotnet/6.0';


### PR DESCRIPTION
Fixes #442.

* Relaxes the .NET runtime version check to only require the .NET Runtime (instead of ASP.NET Core too), and to permit versions later than 6.0.x.
* Make the version check error message more concise, in order to reduce the likelihood that VS Code hides the notification (due to the message being too long to fit on screen).