### PR TITLE
Fix plugin arguments to Dafny server

### DIFF
--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -108,13 +108,13 @@ function getDafnyPluginsArgumentOld(): string[] {
 
 function getDafnyPluginsArgument(): string[] {
   const plugins = Configuration.get<string[]>(ConfigurationConstants.LanguageServer.DafnyPlugins);
-  if(plugins === null || !Array.isArray(plugins)) {
+  if (plugins === null || !Array.isArray(plugins)) {
     return [];
   }
   return (
     plugins
       .filter(plugin => plugin !== null && plugin !== '')
-      .map((plugin, i) => `--plugin:${i}=${plugin}`)
+      .map(plugin => `--plugin:${plugin}`)
   );
 }
 

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -96,7 +96,7 @@ function getMarkGhostStatementsArgument(): string {
 
 function getDafnyPluginsArgumentOld(): string[] {
   const plugins = Configuration.get<string[]>(ConfigurationConstants.LanguageServer.DafnyPlugins);
-  if(plugins === null || !Array.isArray(plugins)) {
+  if (plugins === null || !Array.isArray(plugins)) {
     return [];
   }
   return (


### PR DESCRIPTION
Dafny's `--plugin` argument doesn't expect an index before the path to the plugin DLL, both in terms of how plugin arguments are parsed in the Dafny code and according to the relevant [documentation](https://github.com/dafny-lang/dafny/blob/master/docs/DafnyRef/UserGuide.md#136117-plugins). Confirmed by testing with an example plugin.