### PR TITLE
Fix: Dafny plugins working again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Absolute paths to assemblies to be used as plugins (requires restart and Dafny 3.4.0+).\nExample 1: /user/home/dafnyplugin.dll\nExample 2: /user/home/dafnyplugin.dll,oneArgument\nExample 3: /user/home/dafnyplugin.dll,\"argument with space and \\\" escaped quote\" secondArgument"
+          "description": "(Deprecated, use repeated --plugin:<path> in Language Server Launch Args) Absolute paths to assemblies to be used as plugins (requires restart and Dafny 3.4.0+).\nExample 1: /user/home/dafnyplugin.dll\nExample 2: /user/home/dafnyplugin.dll,oneArgument\nExample 3: /user/home/dafnyplugin.dll,\"argument with space and \\\" escaped quote\" secondArgument"
         },
         "dafny.languageServerLaunchArgs": {
           "type": "array",

--- a/src/language/dafnyLanguageClient.ts
+++ b/src/language/dafnyLanguageClient.ts
@@ -114,7 +114,7 @@ function getDafnyPluginsArgument(): string[] {
   return (
     plugins
       .filter(plugin => plugin !== null && plugin !== '')
-      .map((plugin, i) => `--plugin:${i}=${plugin}`)
+      .map(plugin => `--plugin:${plugin}`)
   );
 }
 


### PR DESCRIPTION
The plugins option of the IDE was no longer working because we were outputting the index. It might not matter that much now that we have project files, but it's now fixed and I also deprecated the options to add plugins this way since regular options work as much as project files.

Fixes https://github.com/dafny-lang/dafny/issues/4759

I did not bother writing tests because it's a deprecated option anyway.