### PR TITLE
Release v3.2.3 (updated Dafny to 4.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 3.2.3
+- Add Dafny 4.5.0
+
 ## 3.2.2
 - Warn users about libraries not being available inside the Dafny IDE (https://github.com/dafny-lang/ide-vscode/pull/454)
 - Fix: Dafny plugins working again. (https://github.com/dafny-lang/ide-vscode/pull/453)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ide-vscode",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ide-vscode",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "publisher": "dafny-lang",
   "repository": {
     "type": "git",
@@ -228,6 +228,7 @@
           "type": "string",
           "enum": [
             "latest stable release",
+            "4.5.0",
             "4.4.0",
             "4.3.0",
             "4.2.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export namespace LanguageServerConstants {
   export const LatestStable = 'latest stable release';
   export const LatestNightly = 'latest nightly';
   export const Custom = 'custom';
-  export const LatestVersion = '4.4.0';
+  export const LatestVersion = '4.5.0';
   export const UnknownVersion = 'unknown';
   export const DafnyGitUrl = 'https://github.com/dafny-lang/dafny.git';
   export const DownloadBaseUri = 'https://github.com/dafny-lang/dafny/releases/download';


### PR DESCRIPTION
(Follows usual process, see e.g. PR for 4.4.0: https://github.com/dafny-lang/ide-vscode/pull/457)