### PR TITLE
Export ExtensionRuntime (or LanguageClient) for other extensions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,14 +14,15 @@ import * as PromiseAny from 'promise.any';
 const DafnyVersionTimeoutMs = 5_000;
 let extensionRuntime: ExtensionRuntime | undefined;
 
-export async function activate(context: ExtensionContext): Promise<void> {
+export async function activate(context: ExtensionContext): Promise<ExtensionRuntime | undefined> {
   if(!await checkAndInformAboutInstallation(context)) {
-    return;
+    return undefined;
   }
   const statusOutput = window.createOutputChannel(ExtensionConstants.ChannelName);
   context.subscriptions.push(statusOutput);
   extensionRuntime = new ExtensionRuntime(context, statusOutput);
   await extensionRuntime.initialize();
+  return extensionRuntime;
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
This change would export the `ExtensionRuntime` object that is created such that other extensions can access it.
This would, for example, allow other extensions to depend on this extension and use the `LanguageClient` it creates to send requests without the need to start their own `LanguageClient`.

With the current changes other extensions could access the `LanguageClient` like this:
```typescript
const client: LanguageClient = vscode.extensions.getExtension('dafny-lang.ide-vscode')?.exports.client;
client.sendRequest(...)
```

Note: Perhaps if exporting `ExtensionRuntime` is a bit too broad, only the `LanguageClient` could be exported instead.