### PR TITLE
Support for @-syntax for attributes

### DIFF
--- a/src/test/highlight/regression-highlight.dfy
+++ b/src/test/highlight/regression-highlight.dfy
@@ -1,3 +1,6 @@
+// This attribute should be colored
+@IsolateAssertions
+
 // Issue #386
 method Test(thisNat: nat, dothis: nat) {
           //^^^^            ^^^^ this should not be highlighted separatedly in blue

--- a/syntaxes/Dafny.tmLanguage
+++ b/syntaxes/Dafny.tmLanguage
@@ -262,6 +262,49 @@
 		<dict>
 			<key>patterns</key>
 			<array>
+			  <dict>
+					<key>begin</key>
+					<string>@([\w'\?]+)\(</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.dafny</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>name</key>
+					<string>attribute</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#code</string>
+						</dict>
+					</array>
+				</dict>
+				
+			  <dict>
+					<key>begin</key>
+					<string>@([\w'\?]+)(?!\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.dafny</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?<=[\w'\?]+)</string>
+					<key>name</key>
+					<string>attribute</string>
+					<key>patterns</key>
+					<array>
+					</array>
+				</dict>
 				<dict>
 					<key>begin</key>
 					<string>\{:(\w+)</string>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/2b54ad18-3bd8-45b0-874b-2bad954706af)

After:
![image](https://github.com/user-attachments/assets/5d4fe1c9-42df-4c55-8680-3e4a66749595)

Related issue
https://github.com/dafny-lang/dafny/issues/5795

@-attributes are now ready on Dafny, and they also have auto-complete from the language server. Having syntax hightlight will make them shine.
I added a "visual regression test". It's unfortunate that they are not programmatically tested, but I hope that we will have semantic highlighting that will get rid of that issue.