### PR TITLE
Fix binary copying to temporary folder on custom path

### DIFF
--- a/src/language/customPathInstaller.ts
+++ b/src/language/customPathInstaller.ts
@@ -107,7 +107,8 @@ export class CustomPathInstaller {
         || file.endsWith('.exe')
         || file === 'z3'
         || file === 'DafnyPrelude.bpl'
-        || file === 'runtimes')) {
+        || file === 'runtimes'
+        || file === executableName)) {
         continue;
       }
       // eslint-disable-next-line max-depth


### PR DESCRIPTION
When you set a custom path for the CLI through `dafny.cliPath`, and set `dafny.version` to `custom`, in theory, the extension should copy all relevant DLL and executable files in the `dafny.cliPath` to a tmp dir, which is then used to launch the language server.

This is implemented by iterating over all files in the directory of the configured path, and copying only the ones which match a given filter: names ending with `.dll`, `.exe`, etc.
On Linux, executables usually won't have those file extensions, and thus, the file the user configured path points to might end up not being copied.
This leads to language server failing because it can't find the file specified in `dafny.cliPath`.

This PR simply changes the filter so that the file pointed to always passes the filter, so that it always ends up getting copied.