### PR TITLE
Update option names

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,13 +200,13 @@
           "default": [],
           "description": "(Deprecated, use repeated --plugin:<path> in Language Server Launch Args) Absolute paths to assemblies to be used as plugins (requires restart and Dafny 3.4.0+).\nExample 1: /user/home/dafnyplugin.dll\nExample 2: /user/home/dafnyplugin.dll,oneArgument\nExample 3: /user/home/dafnyplugin.dll,\"argument with space and \\\" escaped quote\" secondArgument"
         },
-        "dafny.languageServerLaunchArgs": {
+        "dafny.dafnyServerArguments": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "description": "Optional array of strings to pass to the language server. Only works if the Dafny version is 3.10 or greater. Available options can be seen using 'dafny server --help'"
+          "description": "Optional array of strings to use an options when starting 'dafny server', the language server that powers this extension. Only works if the Dafny version is 3.10 or greater. Available options can be seen using 'dafny server --help'"
         },
         "dafny.cliPath": {
           "type": "string",
@@ -218,13 +218,13 @@
           "default": "bin",
           "description": "Absolute or relative path to the compilation output directory."
         },
-        "dafny.runArgs": {
+        "dafny.dafnyRunArguments": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "description": "Optional array of strings as Dafny run and build arguments"
+          "description": "Optional array of strings to pass as options when invoking `dafny run` and `dafny build`. Available options can be seen using 'dafny run --help'"
         },
         "dafny.version": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Optional array of strings to use an options when starting 'dafny server', the language server that powers this extension. Only works if the Dafny version is 3.10 or greater. Available options can be seen using 'dafny server --help'"
+          "description": "Optional array of strings to use an options when starting 'dafny server', the language server that powers this extension. Only works if the Dafny version is 3.10 or greater. Available options can be seen using 'dafny server --help'. Note that for project specific options, it is better to configure them in a Dafny project file, which the Dafny extension then automatically finds and uses."
         },
         "dafny.cliPath": {
           "type": "string",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export namespace ConfigurationConstants {
 
   export namespace LanguageServer {
     export const CliPath = 'cliPath';
-    export const LaunchArgs = 'languageServerLaunchArgs';
+    export const LaunchArgs = 'dafnyServerArguments';
     export const AutomaticVerification = 'automaticVerification';
     export const VerificationTimeLimit = 'verificationTimeLimit';
     export const VerificationVirtualCores = 'verificationVirtualCores';
@@ -30,7 +30,7 @@ export namespace ConfigurationConstants {
 
   export namespace Compiler {
     export const OutputDir = 'compilerOutputDir';
-    export const Arguments = 'runArgs';
+    export const Arguments = 'dafnyRunArguments';
     export const CommandPrefix = 'terminalCommandPrefix';
   }
 


### PR DESCRIPTION
Fixes #219

### Changes

- Rename "Language Server Launch Args" to "Dafny Server Arguments"
- Rename "Run Args" to "Dafny Run Arguments"

Note: this PR makes all currently configured values for these options be lost, so let's make sure we only have to change the name once.

New look:

<img width="1160" alt="Screenshot 2024-11-07 at 13 39 54" src="https://github.com/user-attachments/assets/46fb83fb-af3b-4dae-9ec0-5e3ca9f104fa">



