### PR TITLE
Chore: added instructions on how to view the trace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,6 @@ To view the message exchange trace in VSCode,
 After reloading VSCode and loading a Dafny file, you can now navigate to the View > Output, and select "Dafny Language Server"
 You only need to do this step once.
 
-## View the server log
-
-The language server is producing log that is discarded by default. You 
-
-
-
-
 # Release process
 
 ## Semi-automated release process (preferred)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,24 @@
-# Release process:
+# Debug the language server
+
+To view the message exchange trace in VSCode,
+
+- Menu View > Command Palette
+- Search for: `Preferences: Open user settings (JSON)`
+- Add a comma and the following line if you want to see message exchange between the server and VSCode:
+
+    "dafny-vscode.trace.server": "verbose"
+
+After reloading VSCode and loading a Dafny file, you can now navigate to the View > Output, and select "Dafny Language Server"
+You only need to do this step once.
+
+## View the server log
+
+The language server is producing log that is discarded by default. You 
+
+
+
+
+# Release process
 
 ## Semi-automated release process (preferred)
 


### PR DESCRIPTION
I added instructions in the `CONTRIBUTING.md` about how to view the trace, as I needed this recently, so I know that the steps are correct.