### PR TITLE
Call fs.promises.mkdtemp on the correct path to prevent making a temp dir in $HOME

### DIFF
--- a/src/language/customPathInstaller.ts
+++ b/src/language/customPathInstaller.ts
@@ -90,7 +90,7 @@ export class CustomPathInstaller {
     const depsjson = '.deps.json';
     const installationDir = path.dirname(configuredPath);
     const executableName = path.basename(configuredPath);
-    const vscodeDir = path.join(os.tmpdir(), await fs.promises.mkdtemp('vscode-dafny-dlls-'));
+    const vscodeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'vscode-dafny-dlls-'));
     console.log(`Copying all necessary dlls and executables to ${vscodeDir}...`);
     const cleanup = function() {
       fs.rmdirSync(vscodeDir, { recursive: true });


### PR DESCRIPTION
When using a custom Dafny installation, this extension copies it to a temp directory. However, the `mkdtemp` call has a typo where it uses `vscode-dafny-dlls-'` instead of `path.join(os.tmpdir(), 'vscode-dafny-dlls-')`, which causes the temp directory to appear in VSCode's cwd (in my case $HOME). This PR fixes that.

https://nodejs.org/api/fs.html#fspromisesmkdtempprefix-options also has an example of how to correctly use `mkdtemp`.