### PR TITLE
Fix publish process for Linux systems without xdg-open

### DIFF
--- a/publish_process.js
+++ b/publish_process.js
@@ -184,7 +184,7 @@ function getCommandLine() {
      case 'darwin' : return 'open';
      case 'win32' : return 'start';
      case 'win64' : return 'start';
-     default : return 'xdg-open';
+     default : return '';
   }
 }
 
@@ -246,7 +246,12 @@ async function UpdateChangeLog(currentChangeLogVersion, packageObj, updateChange
     }
     await updateChangeLogWith(newVersion, allRecentCommitMessages, mostRecentDafnyRelease);
     console.log("I changed " + changeLogFile + " to reflect the new version.\nPlease make edits as needed and close the editing window.");
-    await execAsync(getCommandLine() + ' ' + changeLogFile);
+    const cmd = getCommandLine();
+    if (cmd != "") {
+      await execAsync(getCommandLine() + ' ' + changeLogFile);
+    } else {
+      console.log("Please modify " + changeLogFile + " before continuing");
+    }
     if (!ok(await question(`Ready to continue? ${ACCEPT_HINT}`))) {
       console.log("Aborting.");
       throw ABORTED;


### PR DESCRIPTION
This PR fixes an issue in the publish process where systems without `xdg-open` would fail when trying to automatically open the changelog file.

## Changes
- Modified `getCommandLine()` to return empty string for unknown platforms instead of 'xdg-open'
- Provides user guidance when automatic file opening is not available

## Testing
- Tested on a Linux cloud desktop without xdg-open installed
- Was used to release 3.5.0, needed for 3.5.1