### PR TITLE
Fix macOS architecture detection for Dafny downloads

### DIFF
--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -141,11 +141,11 @@ export class GitHubReleaseInstaller {
         const { stdout } = await execAsync('uname -m');
         const systemArch = stdout.trim();
         return systemArch === 'x86_64' ? 'x64' : systemArch === 'arm64' ? 'arm64' : 'x64';
-      } catch (error) {
+      } catch(error: unknown) {
         // Fallback to Node.js detection
         this.writeStatus(`Failed to detect system architecture via uname: ${error}`);
         this.writeStatus('Falling back to Node.js process architecture detection');
-        return os.arch() === 'arm64' ? 'arm64' : 'x64';
+        return os.arch();
       }
     }
     // For non-macOS systems, use Node.js detection (preserve original behavior)

--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -146,8 +146,8 @@ export class GitHubReleaseInstaller {
         return os.arch() === 'arm64' ? 'arm64' : 'x64';
       }
     }
-    // For non-macOS systems, use Node.js detection
-    return os.arch() === 'arm64' ? 'arm64' : 'x64';
+    // For non-macOS systems, use Node.js detection (preserve original behavior)
+    return os.arch();
   }
 
   public async getConfiguredVersion(): Promise<string> {

--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -141,8 +141,10 @@ export class GitHubReleaseInstaller {
         const { stdout } = await execAsync('uname -m');
         const systemArch = stdout.trim();
         return systemArch === 'x86_64' ? 'x64' : systemArch === 'arm64' ? 'arm64' : 'x64';
-      } catch {
+      } catch (error) {
         // Fallback to Node.js detection
+        this.writeStatus(`Failed to detect system architecture via uname: ${error}`);
+        this.writeStatus('Falling back to Node.js process architecture detection');
         return os.arch() === 'arm64' ? 'arm64' : 'x64';
       }
     }

--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -131,7 +131,7 @@ export class GitHubReleaseInstaller {
   }
 
   private async getSystemArchitecture(): Promise<string> {
-    if (os.type() === 'Darwin') {
+    if(os.type() === 'Darwin') {
       // On macOS, use system command to get actual hardware architecture
       // to avoid issues with VS Code running under Rosetta
       try {


### PR DESCRIPTION
## Problem
Users on x86_64 Macs are getting "incompatible architecture" errors because the extension downloads arm64 Dafny releases instead of x64 releases. This happens when VS Code runs under Rosetta or as a Universal Binary, causing `os.arch()` to return incorrect architecture information.

## Solution
Use `uname -m` system command on macOS to get actual hardware architecture instead of relying on Node.js process architecture. Maps `x86_64` → `x64` and `arm64` → `arm64` for correct release downloads. Includes fallback to `os.arch()` if system command fails.

Only affects macOS - other platforms continue using existing logic.

Fixes the issue where extension downloads wrong architecture on macOS.