### PR TITLE
Fix macOS platform suffix: macos-13 → macos-14

### DIFF
--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -26,7 +26,7 @@ function getDafnyPlatformSuffix(version: string): string {
     case 'Windows_NT':
       return 'windows-2022';
     case 'Darwin':
-      return 'macos-13';
+      return 'macos-14';
     default:
       return 'ubuntu-22.04';
     }


### PR DESCRIPTION
Fixes #547

Dafny releases switched from `macos-13` to `macos-14` runners in Dec 2025 (dafny-lang/dafny#6403). All nightlies since then and the next stable release (4.11.1+) produce `macos-14` zips.

Without this fix, macOS users get a 404 when downloading Dafny and silently fall back to a slow source build (cloning the repo and running `dotnet build`).

One-line change in `getDafnyPlatformSuffix`.