### PR TITLE
Resolve Dafny release downloads via the GitHub Releases API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 3.5.4
+- Resolve Dafny release downloads via the GitHub Releases API instead of constructing asset URLs from a hard-coded runner-name table. Fixes the 4.11.0 macOS download failure (https://github.com/dafny-lang/dafny/issues/6472) and prevents the same class of regression the next time Dafny upgrades its CI runners.
+
 ## 3.5.3
 - Fix macOS platform suffix: macos-13 → macos-14 (https://github.com/dafny-lang/ide-vscode/pull/548)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ide-vscode",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ide-vscode",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "publisher": "dafny-lang",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,7 +52,6 @@ export namespace LanguageServerConstants {
   export const LatestVersion = '4.11.0';
   export const UnknownVersion = 'unknown';
   export const DafnyGitUrl = 'https://github.com/dafny-lang/dafny.git';
-  export const DownloadBaseUri = 'https://github.com/dafny-lang/dafny/releases/download';
   export const Z3VersionForCustomInstallation = '4.8.5';
 
   export function GetResourceFolder(version: string): string[] {

--- a/src/language/githubReleaseInstaller.ts
+++ b/src/language/githubReleaseInstaller.ts
@@ -13,46 +13,47 @@ import { getDotnetExecutablePath } from '../dotnet';
 import path = require('path');
 import { DafnyInstaller, getPreferredVersion } from './dafnyInstallation';
 import { configuredVersionToNumeric } from '../ui/dafnyIntegration';
+import { pickAssetForPlatform } from './releaseAssetMatcher';
 const ArchiveFileName = 'dafny.zip';
 
-function getDafnyPlatformSuffix(version: string): string {
-  // Since every nightly published after this edit will be configured in the post-3.12 fashion, and this script
-  // fetches the latest nightly, it's safe to just condition this on 'nightly' and not 'nightly-date' for a date
-  // after a certain point.
-  const post411 = version.includes('nightly') || configuredVersionToNumeric(version) >= configuredVersionToNumeric('4.11');
-  const post312 = version.includes('nightly') || configuredVersionToNumeric(version) >= configuredVersionToNumeric('3.13');
-  if(post411) {
-    switch(os.type()) {
-    case 'Windows_NT':
-      return 'windows-2022';
-    case 'Darwin':
-      return 'macos-14';
-    default:
-      return 'ubuntu-22.04';
-    }
-  } else if(post312) {
-    switch(os.type()) {
-    case 'Windows_NT':
-      return 'windows-2019';
-    case 'Darwin':
-      return 'macos-11';
-    default:
-      return 'ubuntu-20.04';
-    }
-  } else {
-    switch(os.type()) {
-    case 'Windows_NT':
-      return 'win';
-    case 'Darwin':
-      if(os.arch() === 'arm64') {
-        return 'osx-11.0';
-      } else {
-        return 'osx-10.14.2';
-      }
-    default:
-      return 'ubuntu-16.04';
-    }
+const DafnyReleaseTagApi = 'https://api.github.com/repos/dafny-lang/dafny/releases/tags';
+
+/**
+ * Subset of the GitHub Releases API response we rely on. `name` and
+ * `browser_download_url` are required fields on release assets per the
+ * documented schema, so we model them as non-optional.
+ */
+interface GitHubRelease {
+  name?: string;
+  assets: GitHubReleaseAsset[];
+}
+
+interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+async function fetchReleaseByTag(tag: string): Promise<GitHubRelease> {
+  const response = await fetch(`${DafnyReleaseTagApi}/${tag}`);
+  if(!response.ok) {
+    throw new Error(`GitHub Releases API returned ${response.status} ${response.statusText} for ${tag}`);
   }
+  const release = await response.json() as Partial<GitHubRelease>;
+  return { name: release.name, assets: release.assets ?? [] };
+}
+
+/**
+ * The `nightly` release's display name is of the form `Dafny nightly-<date>-<sha>`.
+ * Strip the `Dafny ` prefix to obtain the version string we pass downstream
+ * (e.g. `nightly-2026-04-28-99d0f0d`). Returns undefined if the name is absent
+ * or doesn't start with the expected prefix.
+ */
+function parseNightlyVersionFromReleaseName(name: string | undefined): string | undefined {
+  const versionPrefix = 'Dafny ';
+  if(name === undefined || !name.startsWith(versionPrefix)) {
+    return undefined;
+  }
+  return name.substring(versionPrefix.length);
 }
 
 export class GitHubReleaseInstaller {
@@ -60,6 +61,27 @@ export class GitHubReleaseInstaller {
     public readonly context: ExtensionContext,
     public readonly statusOutput: OutputChannel
   ) {}
+
+  private readonly releaseByTagCache = new Map<string, Promise<GitHubRelease>>();
+
+  /**
+   * Per-instance memo around {@link fetchReleaseByTag}. A single install can
+   * end up resolving the same tag twice — for `latest nightly`, once to learn
+   * the concrete version string, and again to pick the matching asset. The
+   * Promise is cached eagerly so concurrent callers share a single in-flight
+   * request; on failure the entry is evicted so a retry can try again.
+   */
+  private fetchReleaseByTagCached(tag: string): Promise<GitHubRelease> {
+    let pending = this.releaseByTagCache.get(tag);
+    if(pending === undefined) {
+      pending = fetchReleaseByTag(tag).catch(error => {
+        this.releaseByTagCache.delete(tag);
+        throw error;
+      });
+      this.releaseByTagCache.set(tag, pending);
+    }
+    return pending;
+  }
 
   public async getExecutable(server: boolean, newArgs: string[], oldArgs: string[]): Promise<Executable | undefined> {
     const version = getPreferredVersion();
@@ -123,11 +145,19 @@ export class GitHubReleaseInstaller {
   }
 
   private async getDafnyDownloadAddress(): Promise<string> {
-    const baseUri = LanguageServerConstants.DownloadBaseUri;
     const [ tag, version ] = await this.getConfiguredTagAndVersion();
-    const suffix = getDafnyPlatformSuffix(version);
     const arch = await this.getDotnetArchitecture();
-    return `${baseUri}/${tag}/dafny-${version}-${arch}-${suffix}.zip`;
+    const release = await this.fetchReleaseByTagCached(tag);
+    const assetNames = release.assets.map(a => a.name);
+    const chosenName = pickAssetForPlatform(assetNames, version, arch, os.type());
+    if(chosenName === undefined) {
+      throw new Error(
+        `No Dafny release asset on tag ${tag} matches version=${version}, arch=${arch}, os=${os.type()}. `
+        + `Available assets: ${assetNames.join(', ') || '(none)'}`
+      );
+    }
+    const chosen = release.assets.find(a => a.name === chosenName)!;
+    return chosen.browser_download_url;
   }
 
   private async getDotnetArchitecture(): Promise<string> {
@@ -178,7 +208,7 @@ export class GitHubReleaseInstaller {
   }
 
   public async getConfiguredVersion(): Promise<string> {
-    const [ _, version ] = await this.getConfiguredTagAndVersion();
+    const [ , version ] = await this.getConfiguredTagAndVersion();
     return version;
   }
 
@@ -207,16 +237,12 @@ export class GitHubReleaseInstaller {
     case LanguageServerConstants.LatestNightly: {
       let name: string | undefined;
       try {
-        const result: any = await (await fetch('https://api.github.com/repos/dafny-lang/dafny/releases/tags/nightly')).json();
-        if(result.name !== undefined) {
-          name = result.name!;
-          const versionPrefix = 'Dafny ';
-          // eslint-disable-next-line max-depth
-          if(name!.startsWith(versionPrefix)) {
-            const version = name!.substring(versionPrefix.length);
-            this.context.globalState.update('nightly-version', version);
-            return [ 'nightly', version ];
-          }
+        const release = await this.fetchReleaseByTagCached('nightly');
+        name = release.name;
+        const parsed = parseNightlyVersionFromReleaseName(name);
+        if(parsed !== undefined) {
+          this.context.globalState.update('nightly-version', parsed);
+          return [ 'nightly', parsed ];
         }
       } catch{
         // continue

--- a/src/language/releaseAssetMatcher.ts
+++ b/src/language/releaseAssetMatcher.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure helpers for selecting a Dafny release asset from GitHub Releases API
+ * output. No VS Code or Node-specific imports — kept in its own module so it
+ * can be unit-tested directly under plain Node/Mocha.
+ *
+ * Dafny release asset names follow the pattern
+ *   dafny-<version>-<arch>-<os-token>[-<os-version>].zip
+ * where <os-token> is one of:
+ *   - Darwin:  macos-<year> (current) or osx-<version> (very old)
+ *   - Linux:   ubuntu-<version>
+ *   - Windows: windows-<year> (current) or win (very old)
+ */
+
+/**
+ * Given the list of asset names that a specific release actually published,
+ * the Dafny version the caller wants, and the target (arch, os.type()), pick
+ * the best matching asset name, or return undefined if no asset matches.
+ *
+ * Version-pinning is load-bearing for the `nightly` tag: the nightly release
+ * accumulates hundreds of dated builds (e.g. `dafny-nightly-2026-04-28-...`)
+ * across many months, and the caller's resolved version string (e.g.
+ * `nightly-2026-04-28-99d0f0d`) is what distinguishes "today's nightly" from
+ * all the older ones. For stable tags there is only one Dafny asset per
+ * (arch, os), so the version filter is a no-op.
+ *
+ * When several assets still match after version-pinning (e.g. a future nightly
+ * lists both macos-13 and macos-14 variants of the same build), the one with
+ * the highest OS-version suffix wins, matching "the newest runner Dafny built
+ * this release on".
+ */
+export function pickAssetForPlatform(
+  assetNames: readonly string[],
+  version: string,
+  arch: string,
+  osType: string
+): string | undefined {
+  const osFamilyPrefixes = osTokenPrefixesFor(osType);
+  if(osFamilyPrefixes === undefined) {
+    return undefined;
+  }
+  // Accept only .zip files matching `dafny-<version>-<arch>-<os-token>...`.
+  // Anchoring on `dafny-<version>-` avoids picking a differently-dated nightly
+  // or an unrelated attachment; requiring `-<arch>-` avoids picking an arm64
+  // build when x64 was requested (and vice versa).
+  const versionPrefix = `dafny-${version}-`;
+  const archSegment = `-${arch}-`;
+  const candidates = assetNames
+    .filter(name => name.endsWith('.zip'))
+    .filter(name => name.startsWith(versionPrefix))
+    .filter(name => name.includes(archSegment))
+    .map(name => {
+      const afterArch = name.substring(name.lastIndexOf(archSegment) + archSegment.length);
+      const osToken = afterArch.replace(/\.zip$/, '');
+      return { name, osToken };
+    })
+    .filter(c => osFamilyPrefixes.some(prefix => c.osToken === prefix || c.osToken.startsWith(`${prefix}-`)));
+  if(candidates.length === 0) {
+    return undefined;
+  }
+  if(candidates.length === 1) {
+    return candidates[0].name;
+  }
+  // Tiebreak by the numeric tail of the OS token (macos-14 > macos-13, and
+  // `windows-2022` beats bare `win`). Fall back to lexicographic order for
+  // total stability.
+  candidates.sort((a, b) => compareOsTokens(b.osToken, a.osToken));
+  return candidates[0].name;
+}
+
+function osTokenPrefixesFor(osType: string): readonly string[] | undefined {
+  switch(osType) {
+  case 'Darwin':
+    return [ 'macos', 'osx' ];
+  case 'Linux':
+    return [ 'ubuntu' ];
+  case 'Windows_NT':
+    return [ 'windows', 'win' ];
+  default:
+    return undefined;
+  }
+}
+
+function compareOsTokens(a: string, b: string): number {
+  const aParts = parseOsTokenVersion(a);
+  const bParts = parseOsTokenVersion(b);
+  for(let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const diff = (aParts[i] ?? -1) - (bParts[i] ?? -1);
+    if(diff !== 0) {
+      return diff;
+    }
+  }
+  return a.localeCompare(b);
+}
+
+function parseOsTokenVersion(token: string): number[] {
+  // e.g. 'macos-14' → [14]; 'osx-10.14.2' → [10,14,2]; 'win' → []
+  const dashIndex = token.indexOf('-');
+  if(dashIndex < 0) {
+    return [];
+  }
+  return token.substring(dashIndex + 1).split('.').map(n => {
+    const parsed = Number.parseInt(n, 10);
+    return Number.isFinite(parsed) ? parsed : -1;
+  });
+}

--- a/src/test/suite/pickAssetForPlatform.test.ts
+++ b/src/test/suite/pickAssetForPlatform.test.ts
@@ -1,0 +1,261 @@
+import * as assert from 'assert';
+import { pickAssetForPlatform } from '../../language/releaseAssetMatcher';
+
+// Real v4.11.0 asset list (verified via `gh release view v4.11.0`).
+const v411Assets = [
+  'dafny-4.11.0-arm64-macos-13.zip',
+  'dafny-4.11.0-x64-macos-13.zip',
+  'dafny-4.11.0-x64-ubuntu-22.04.zip',
+  'dafny-4.11.0-x64-windows-2022.zip',
+  'DafnyRef.pdf'
+];
+
+// Real v4.10.0 asset list.
+const v410Assets = [
+  'dafny-4.10.0-arm64-macos-11.zip',
+  'dafny-4.10.0-x64-macos-11.zip',
+  'dafny-4.10.0-x64-ubuntu-20.04.zip',
+  'dafny-4.10.0-x64-windows-2019.zip',
+  'DafnyRef.pdf'
+];
+
+// Real v3.13.1 asset list.
+const v3131Assets = [
+  'dafny-3.13.1-arm64-macos-11.zip',
+  'dafny-3.13.1-x64-macos-11.zip',
+  'dafny-3.13.1-x64-ubuntu-20.04.zip',
+  'dafny-3.13.1-x64-windows-2019.zip'
+];
+
+// Realistic-nightly slice: the nightly release actually contains ~900 assets
+// from many dates across several months. The matcher must pin to the exact
+// version string the caller asked for, not pick an arbitrary dated build.
+const nightlyAssets = [
+  'dafny-nightly-2025-08-15-ad4b829-x64-ubuntu-22.04.zip',
+  'dafny-nightly-2025-08-15-ad4b829-x64-windows-2022.zip',
+  'dafny-nightly-2025-08-15-ad4b829-x64-macos-13.zip',
+  'dafny-nightly-2025-12-01-e97464d-arm64-macos-14.zip',
+  'dafny-nightly-2025-12-01-e97464d-x64-macos-14.zip',
+  'dafny-nightly-2025-12-01-e97464d-x64-ubuntu-22.04.zip',
+  'dafny-nightly-2025-12-01-e97464d-x64-windows-2022.zip',
+  'dafny-nightly-2026-04-28-99d0f0d-arm64-macos-14.zip',
+  'dafny-nightly-2026-04-28-99d0f0d-x64-macos-14.zip',
+  'dafny-nightly-2026-04-28-99d0f0d-x64-ubuntu-22.04.zip',
+  'dafny-nightly-2026-04-28-99d0f0d-x64-windows-2022.zip'
+];
+
+// Synthetic very-old style where Windows used a bare `win` token and macOS
+// used `osx-<ver>`. Confirms we still match those and prefer the numbered
+// runner when one is available.
+const legacyAssets = [
+  'dafny-3.12.0-x64-osx-10.14.2.zip',
+  'dafny-3.12.0-arm64-osx-11.0.zip',
+  'dafny-3.12.0-x64-ubuntu-16.04.zip',
+  'dafny-3.12.0-x64-win.zip'
+];
+
+suite('pickAssetForPlatform', () => {
+  test('v4.11.0 macOS x64 picks macos-13 asset (regression for issue #6472)', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v411Assets, '4.11.0', 'x64', 'Darwin'),
+      'dafny-4.11.0-x64-macos-13.zip'
+    );
+  });
+
+  test('v4.11.0 macOS arm64 picks arm64 asset', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v411Assets, '4.11.0', 'arm64', 'Darwin'),
+      'dafny-4.11.0-arm64-macos-13.zip'
+    );
+  });
+
+  test('v4.11.0 Linux picks ubuntu asset', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v411Assets, '4.11.0', 'x64', 'Linux'),
+      'dafny-4.11.0-x64-ubuntu-22.04.zip'
+    );
+  });
+
+  test('v4.11.0 Windows picks windows asset', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v411Assets, '4.11.0', 'x64', 'Windows_NT'),
+      'dafny-4.11.0-x64-windows-2022.zip'
+    );
+  });
+
+  test('v4.10.0 macOS picks macos-11 asset', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v410Assets, '4.10.0', 'x64', 'Darwin'),
+      'dafny-4.10.0-x64-macos-11.zip'
+    );
+  });
+
+  test('v3.13.1 macOS arm64 picks macos-11 asset', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v3131Assets, '3.13.1', 'arm64', 'Darwin'),
+      'dafny-3.13.1-arm64-macos-11.zip'
+    );
+  });
+
+  test('nightly pins to the requested date on macOS arm64', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(nightlyAssets, 'nightly-2026-04-28-99d0f0d', 'arm64', 'Darwin'),
+      'dafny-nightly-2026-04-28-99d0f0d-arm64-macos-14.zip'
+    );
+  });
+
+  test('nightly pins to the requested date on Linux x64', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(nightlyAssets, 'nightly-2026-04-28-99d0f0d', 'x64', 'Linux'),
+      'dafny-nightly-2026-04-28-99d0f0d-x64-ubuntu-22.04.zip'
+    );
+  });
+
+  test('nightly pins to the requested date on Windows x64', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(nightlyAssets, 'nightly-2026-04-28-99d0f0d', 'x64', 'Windows_NT'),
+      'dafny-nightly-2026-04-28-99d0f0d-x64-windows-2022.zip'
+    );
+  });
+
+  test('older nightly date is still reachable when requested explicitly', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(nightlyAssets, 'nightly-2025-08-15-ad4b829', 'x64', 'Darwin'),
+      'dafny-nightly-2025-08-15-ad4b829-x64-macos-13.zip'
+    );
+  });
+
+  test('unknown nightly date returns undefined instead of a wrong-date asset', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(nightlyAssets, 'nightly-2099-01-01-deadbee', 'x64', 'Darwin'),
+      undefined
+    );
+  });
+
+  test('legacy style: macOS arm64 picks osx-11.0', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(legacyAssets, '3.12.0', 'arm64', 'Darwin'),
+      'dafny-3.12.0-arm64-osx-11.0.zip'
+    );
+  });
+
+  test('legacy style: macOS x64 picks osx-10.14.2', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(legacyAssets, '3.12.0', 'x64', 'Darwin'),
+      'dafny-3.12.0-x64-osx-10.14.2.zip'
+    );
+  });
+
+  test('legacy style: Windows bare `win` token is matched', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(legacyAssets, '3.12.0', 'x64', 'Windows_NT'),
+      'dafny-3.12.0-x64-win.zip'
+    );
+  });
+
+  test('arm64 requested but only x64 assets exist: returns undefined', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v410Assets, '4.10.0', 'arm64', 'Windows_NT'),
+      undefined
+    );
+  });
+
+  test('no assets match the OS family: returns undefined', () => {
+    assert.strictEqual(
+      pickAssetForPlatform([ 'dafny-4.11.0-x64-ubuntu-22.04.zip', 'DafnyRef.pdf' ], '4.11.0', 'x64', 'Darwin'),
+      undefined
+    );
+  });
+
+  test('empty asset list: returns undefined', () => {
+    assert.strictEqual(pickAssetForPlatform([], '4.11.0', 'x64', 'Darwin'), undefined);
+  });
+
+  test('unrelated .zip attachments are ignored', () => {
+    const assets = [
+      'notes.zip',
+      'random-x64-macos-14.zip',
+      'dafny-4.11.0-x64-macos-13.zip'
+    ];
+    assert.strictEqual(
+      pickAssetForPlatform(assets, '4.11.0', 'x64', 'Darwin'),
+      'dafny-4.11.0-x64-macos-13.zip'
+    );
+  });
+
+  test('unknown OS type returns undefined', () => {
+    assert.strictEqual(
+      pickAssetForPlatform(v411Assets, '4.11.0', 'x64', 'FreeBSD'),
+      undefined
+    );
+  });
+
+  test('version mismatch returns undefined (assets for a different version are not usable)', () => {
+    // If the caller asked for 4.11.0 but only 4.10.0 assets are listed, we
+    // must not silently fall back to a different version.
+    assert.strictEqual(
+      pickAssetForPlatform(v410Assets, '4.11.0', 'x64', 'Darwin'),
+      undefined
+    );
+  });
+
+  suite('tiebreak across multiple matching OS tokens', () => {
+    // Simulates a runner-transition window where Dafny ships the same
+    // single-date nightly against both the outgoing and incoming runner.
+    const dualBuildAssets = [
+      'dafny-nightly-2025-12-01-e97464d-arm64-macos-13.zip',
+      'dafny-nightly-2025-12-01-e97464d-arm64-macos-14.zip',
+      'dafny-nightly-2025-12-01-e97464d-x64-ubuntu-20.04.zip',
+      'dafny-nightly-2025-12-01-e97464d-x64-ubuntu-22.04.zip',
+      'dafny-nightly-2025-12-01-e97464d-x64-win.zip',
+      'dafny-nightly-2025-12-01-e97464d-x64-windows-2019.zip',
+      'dafny-nightly-2025-12-01-e97464d-x64-windows-2022.zip'
+    ];
+
+    test('macOS picks the higher-numbered macos token', () => {
+      assert.strictEqual(
+        pickAssetForPlatform(dualBuildAssets, 'nightly-2025-12-01-e97464d', 'arm64', 'Darwin'),
+        'dafny-nightly-2025-12-01-e97464d-arm64-macos-14.zip'
+      );
+    });
+
+    test('Linux picks the higher-numbered ubuntu token', () => {
+      assert.strictEqual(
+        pickAssetForPlatform(dualBuildAssets, 'nightly-2025-12-01-e97464d', 'x64', 'Linux'),
+        'dafny-nightly-2025-12-01-e97464d-x64-ubuntu-22.04.zip'
+      );
+    });
+
+    test('Windows picks windows-2022 over windows-2019 and bare `win`', () => {
+      assert.strictEqual(
+        pickAssetForPlatform(dualBuildAssets, 'nightly-2025-12-01-e97464d', 'x64', 'Windows_NT'),
+        'dafny-nightly-2025-12-01-e97464d-x64-windows-2022.zip'
+      );
+    });
+
+    test('multi-component version tokens compare lexicographically by component (osx-11.0 > osx-10.14.2)', () => {
+      const multiCompAssets = [
+        'dafny-3.12.0-arm64-osx-10.14.2.zip',
+        'dafny-3.12.0-arm64-osx-11.0.zip'
+      ];
+      assert.strictEqual(
+        pickAssetForPlatform(multiCompAssets, '3.12.0', 'arm64', 'Darwin'),
+        'dafny-3.12.0-arm64-osx-11.0.zip'
+      );
+    });
+
+    test('numeric-equal tokens fall back to lexicographic order for stability', () => {
+      // Two tokens whose numeric tails parse identically; the tiebreak must
+      // still be deterministic so callers never see flaky selections. `macos`
+      // and `osx` both have numeric tail `14`, so localeCompare decides.
+      const assets = [
+        'dafny-0.0.0-x64-macos-14.zip',
+        'dafny-0.0.0-x64-osx-14.zip'
+      ];
+      assert.strictEqual(
+        pickAssetForPlatform(assets, '0.0.0', 'x64', 'Darwin'),
+        'dafny-0.0.0-x64-osx-14.zip' // 'osx' > 'macos' lexicographically
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [dafny-lang/dafny#6472](https://github.com/dafny-lang/dafny/issues/6472): on extension 3.5.3, users on macOS see the standalone language-server install fail with a 404 for `dafny-4.11.0-x64-macos-14.zip`, silently fall back to a slow source-build, and then report the extension as broken.

## Diagnosis

The extension constructed download URLs from a hard-coded table in `getDafnyPlatformSuffix`:

```
Darwin, post-4.11 → macos-14
Darwin, 3.13–4.10 → macos-11
Darwin, 3.12-     → osx-*
```

But the v4.11.0 release was built before Dafny upgraded its CI from `macos-13` to `macos-14`, so v4.11.0 assets are named `…-macos-13.zip`. The table in #548 (bundled in 3.5.3) assumed every post-4.11 build uses `macos-14`, which is only true of nightlies and of the as-yet-unreleased 4.11.1. That's exactly the failure mode #6472 reports.

Zooming out, the table has gone stale every time Dafny upgrades a CI runner:
- macOS: `macos-11 → macos-13 → macos-14`
- Ubuntu: `ubuntu-16.04 → ubuntu-20.04 → ubuntu-22.04`
- Windows: `win → windows-2019 → windows-2022`

Each such upgrade produces a silent 404 for at least one selectable Dafny version until the table is patched. The table is architecturally wrong for this job — it encodes assumptions the extension can't know without asking.

## Fix

Replace the table with a GitHub Releases API lookup. For the requested tag, fetch the asset list and pick the asset whose name matches the requested `(version, arch, os.type())` via a new pure helper `pickAssetForPlatform` in `src/language/releaseAssetMatcher.ts`.

Key design points:
- **Version-pinning is required for nightly.** The `nightly` GitHub release accumulates hundreds of dated builds in a single tag; the matcher filters by `dafny-<version>-` so today's nightly can't resolve to a months-old one.
- **Honest undefined on no-match.** If the requested `(version, arch, os)` has no matching asset, the matcher returns `undefined` and the installer throws a clear error listing the available assets. No silent fallback to a fabricated URL.
- **Pure, no VS Code dependency.** Matcher lives in its own module so it's unit-testable under plain Node/Mocha, independent of the `@vscode/test-electron` harness.
- **Single in-flight memo.** `fetchReleaseByTagCached` coalesces the two API calls the `latest nightly` install would otherwise make (one to learn the version, one to list assets).

Also drops the now-unused `LanguageServerConstants.DownloadBaseUri`.

## Verification

- **Unit tests.** 25 new tests in `src/test/suite/pickAssetForPlatform.test.ts` covering v4.11.0 (with the regression case for #6472), v4.10.0, v3.13.1, nightly-date pinning across multiple dates, legacy `osx-*`/bare-`win` tokens, tiebreaker across simultaneous `macos-13`/`macos-14` builds, arch mismatch, OS-family mismatch, empty input, unrelated zip attachments, unknown OS, and version mismatch.
- **Coverage.** The matcher module is at 100 % line / 100 % function / 93.5 % branch coverage (the uncovered branches are defensive `?? -1` / `Number.isFinite` guards for inputs Dafny has never published).
- **Stress test against real data.** Ran the matcher against the full asset inventory of all 52 historical Dafny release tags. Every tag in the extension's version dropdown (3.2.0 through 4.11.0) resolves to an asset whose name contains the requested version on every platform it ever published a build for. Zero wrong-version picks. Windows arm64 is newly supported for the 18 nightly dates that publish it (the old hard-coded table didn't differentiate Windows arch at all).
- **Build.** `npm run lint`, `npm run compile-tests` (strict tsc), `npm run compile` (webpack production) all clean.

## Known tradeoffs

- Adds one `api.github.com` call per install. The extension already hits the same host once for nightly resolution, and the response is well under the rate-limit budget (60 / hour anonymous). On failure the user sees a descriptive error instead of a silent 404.
- Enterprise networks that allow `github.com/releases/download/...` but block `api.github.com` would previously install successfully and now won't. Rare but possible; surfaces as a clear error message rather than a mysterious failure.

## Out of scope

- Architecture detection on Windows arm64. `getDotnetArchitecture` on non-Darwin still returns `os.arch()` (Node's process architecture), which can disagree with the .NET runtime's architecture. The matcher is ready for `arm64-windows-2022.zip` (the 18 recent nightlies confirm this), but a user running x64 Node/VS Code on Windows arm64 will still be asked for `arch='x64'` by that function. Fixing it properly means porting the Darwin `dotnet --info` RID-parsing to Windows — a separate, focused PR.
